### PR TITLE
feat(ux): scope-setup guidance banner + OpenSettings context — v1.1.0…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to Dataverse Request Studio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-05-25
+
+### ✨ Added
+
+- **Scope-setup guidance banner** — when the tool loads with the entity scope
+  unconfigured (i.e. `entityScopeMode` is `publisher-solution` or
+  `solution-only` but no solutions have been selected), a contextual
+  `MessageBar` (warning intent) is shown at the top of the Target pane across
+  **all 14 modes** that use `TargetEditor`. The banner provides a mode-specific
+  hint and an **Open Settings** button that opens the Settings drawer directly.
+  It disappears automatically once the user selects a publisher / solution (or
+  switches to *All Entities*) — no dismiss cookie required, because the
+  condition is purely reactive to the persisted `DisplaySettings` state.
+
+- **`OpenSettingsProvider` / `useOpenSettings` / `useRegisterOpenSettings`**
+  (`src/host/useOpenSettings.tsx`) — new React context that provides a
+  stable `() => void` callback to open the Settings drawer from any component
+  in the tree without prop-drilling. Uses a ref-based registration pattern
+  (zero provider re-renders). `FrameHeader` registers the callback on mount;
+  any consumer calls `useOpenSettings()` to get it.
+
+- **`useScopedEntities` now exposes `needsSetup: boolean` and
+  `scopeMode: EntityScopeMode`** — consumers can detect the
+  unconfigured-scope condition and tailor guidance text accordingly.
+
+### 🔍 Settings persistence confirmation
+
+- Verified that all `DisplaySettings` (scope mode, selected publisher /
+  solution IDs, display flags) are persisted via `window.toolboxAPI.settings`
+  under the namespaced key `pptb-dataverse-request-studio:displaySettings`.
+  The prefix is distinct from other PPTB tools (e.g. FetchXML Studio). No
+  changes to the persistence layer were required.
+
+---
+
 ## [1.0.0] - 2026-05-24
 
 Initial public release of Dataverse Request Studio — a metadata-driven studio

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@mohsinonxrm/pptb-dataverse-request-studio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mohsinonxrm/pptb-dataverse-request-studio",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -2722,9 +2722,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2739,9 +2736,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2756,9 +2750,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2773,9 +2764,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2790,9 +2778,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2807,9 +2792,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2824,9 +2806,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2841,9 +2820,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2858,9 +2834,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2875,9 +2848,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2892,9 +2862,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2909,9 +2876,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2926,9 +2890,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,98 +1,98 @@
 {
-  "name": "@mohsinonxrm/pptb-dataverse-request-studio",
-  "version": "1.0.0",
-  "publishConfig": {
-    "access": "public"
-  },
-  "type": "module",
-  "displayName": "Dataverse Request Studio",
-  "description": "Compose, preview, and execute Microsoft Dataverse Web API requests — a metadata-driven studio for OData queries, record writes, associations, action/function/workflow invocation, and file/image/attachment operations. Embeds in Power Platform ToolBox.",
-  "homepage": "https://dataverserequest.studio",
-  "author": "mohsinonxrm",
-  "main": "index.html",
-  "icon": "icons/icon.svg",
-  "license": "AGPL-3.0-only",
-  "contributors": [
-    {
-      "name": "Mohsin Mirza",
-      "url": "https://github.com/mohsinonxrm"
-    },
-    {
-      "name": "Guido Preite",
-      "url": "https://github.com/GuidoPreite"
-    }
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/mohsinonxrm/pptb-mxrm-dataverse-request-studio.git"
-  },
-  "bugs": {
-    "url": "https://github.com/mohsinonxrm/pptb-mxrm-dataverse-request-studio/issues"
-  },
-  "keywords": [
-    "dataverse",
-    "power-platform",
-    "power-apps",
-    "dynamics-365",
-    "webapi",
-    "odata",
-    "request-builder",
-    "studio",
-    "pptb",
-    "toolbox",
-    "attribute-metadata",
-    "fetchxml",
-    "crm",
-    "xrm",
-    "microsoft"
-  ],
-  "features": {
-    "multiConnection": "none",
-    "minAPI": "1.2.0"
-  },
-  "configurations": {
-    "repository": "https://github.com/mohsinonxrm/pptb-mxrm-dataverse-request-studio",
-    "website": "https://dataverserequest.studio",
-    "readmeUrl": "https://raw.githubusercontent.com/mohsinonxrm/pptb-mxrm-dataverse-request-studio/refs/heads/main/README.md"
-  },
-  "files": [
-    "dist",
-    "icons",
-    "index.html",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
-    "SECURITY.md",
-    "npm-shrinkwrap.json"
-  ],
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "preview": "vite preview",
-    "typecheck": "tsc -b --noEmit",
-    "validate": "pptb-validate",
-    "finalize-package": "npm run validate && npm run build && npm shrinkwrap"
-  },
-  "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
-    "@fluentui-contrib/react-data-grid-react-window": "^1.4.2",
-    "@fluentui/react-components": "^9.73.8",
-    "@fluentui/react-datepicker-compat": "^0.6.31",
-    "@fluentui/react-icons": "^2.0.326",
-    "@fluentui/react-timepicker-compat": "^0.4.34",
-    "@monaco-editor/react": "^4.7.0",
-    "monaco-editor": "^0.54.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
-  },
-  "devDependencies": {
-    "@pptb/types": "^1.2.1",
-    "@types/react": "^18.3.28",
-    "@types/react-dom": "^18.3.7",
-    "@vitejs/plugin-react": "^5.2.0",
-    "typescript": "~5.9.3",
-    "vite": "^7.3.3"
-  }
+	"name": "@mohsinonxrm/pptb-dataverse-request-studio",
+	"version": "1.1.0",
+	"publishConfig": {
+		"access": "public"
+	},
+	"type": "module",
+	"displayName": "Dataverse Request Studio",
+	"description": "Compose, preview, and execute Microsoft Dataverse Web API requests — a metadata-driven studio for OData queries, record writes, associations, action/function/workflow invocation, and file/image/attachment operations. Embeds in Power Platform ToolBox.",
+	"homepage": "https://dataverserequest.studio",
+	"author": "Mohsin On xRM",
+	"main": "index.html",
+	"icon": "icons/icon.svg",
+	"license": "AGPL-3.0-only",
+	"contributors": [
+		{
+			"name": "Mohsin On xRM",
+			"url": "https://github.com/mohsinonxrm"
+		},
+		{
+			"name": "Guido Preite",
+			"url": "https://github.com/GuidoPreite"
+		}
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/mohsinonxrm/pptb-mxrm-dataverse-request-studio.git"
+	},
+	"bugs": {
+		"url": "https://github.com/mohsinonxrm/pptb-mxrm-dataverse-request-studio/issues"
+	},
+	"keywords": [
+		"dataverse",
+		"power-platform",
+		"power-apps",
+		"dynamics-365",
+		"webapi",
+		"odata",
+		"request-builder",
+		"studio",
+		"pptb",
+		"toolbox",
+		"attribute-metadata",
+		"fetchxml",
+		"crm",
+		"xrm",
+		"microsoft"
+	],
+	"features": {
+		"multiConnection": "none",
+		"minAPI": "1.2.0"
+	},
+	"configurations": {
+		"repository": "https://github.com/mohsinonxrm/pptb-mxrm-dataverse-request-studio",
+		"website": "https://dataverserequest.studio",
+		"readmeUrl": "https://raw.githubusercontent.com/mohsinonxrm/pptb-mxrm-dataverse-request-studio/refs/heads/main/README.md"
+	},
+	"files": [
+		"dist",
+		"icons",
+		"index.html",
+		"LICENSE",
+		"README.md",
+		"CHANGELOG.md",
+		"SECURITY.md",
+		"npm-shrinkwrap.json"
+	],
+	"scripts": {
+		"dev": "vite",
+		"build": "tsc -b && vite build",
+		"preview": "vite preview",
+		"typecheck": "tsc -b --noEmit",
+		"validate": "pptb-validate",
+		"finalize-package": "npm run validate && npm run build && npm shrinkwrap"
+	},
+	"dependencies": {
+		"@dnd-kit/core": "^6.3.1",
+		"@dnd-kit/sortable": "^10.0.0",
+		"@dnd-kit/utilities": "^3.2.2",
+		"@fluentui-contrib/react-data-grid-react-window": "^1.4.2",
+		"@fluentui/react-components": "^9.73.8",
+		"@fluentui/react-datepicker-compat": "^0.6.31",
+		"@fluentui/react-icons": "^2.0.326",
+		"@fluentui/react-timepicker-compat": "^0.4.34",
+		"@monaco-editor/react": "^4.7.0",
+		"monaco-editor": "^0.54.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
+	},
+	"devDependencies": {
+		"@pptb/types": "^1.2.1",
+		"@types/react": "^18.3.28",
+		"@types/react-dom": "^18.3.7",
+		"@vitejs/plugin-react": "^5.2.0",
+		"typescript": "~5.9.3",
+		"vite": "^7.3.3"
+	}
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,134 +1,169 @@
-import { useEffect, useState } from 'react';
-import { FluentProvider } from '@fluentui/react-components';
-import { useStudioStyles } from './primitives/styles';
-import { studioLight, studioDark, applyThemeAttr, type ThemeMode } from './theme/theme';
-import { FrameHeader } from './shell/FrameHeader';
-import { SaveContextRoot, type SaveContextValue } from './state/SaveContext';
-import { findRequestType } from './registry/requestTypes';
-import { RetrieveMultipleMode } from './modes/RetrieveMultipleMode';
-import { RetrieveSingleMode } from './modes/RetrieveSingleMode';
-import { RetrieveNextLinkMode } from './modes/RetrieveNextLinkMode';
-import { PredefinedQueryMode } from './modes/PredefinedQueryMode';
-import { CreateMode } from './modes/CreateMode';
-import { UpdateMode } from './modes/UpdateMode';
-import { UpsertMode } from './modes/UpsertMode';
-import { DeleteMode } from './modes/DeleteMode';
-import { MergeMode } from './modes/MergeMode';
-import { AssociateMode } from './modes/AssociateMode';
-import { DisassociateMode } from './modes/DisassociateMode';
-import { ExecuteActionMode } from './modes/ExecuteActionMode';
-import { ExecuteFunctionMode } from './modes/ExecuteFunctionMode';
-import { ExecuteWorkflowMode } from './modes/ExecuteWorkflowMode';
-import { ManageFileMode } from './modes/ManageFileMode';
-import { ManageImageMode } from './modes/ManageImageMode';
-import { ManageAttachmentMode } from './modes/ManageAttachmentMode';
-import { StubMode } from './modes/StubMode';
-import { findTable } from './mock/metadata';
-import { _setTableLookup } from './editors/filter/filterTree';
-import { HostProvider, useHostSession } from './host/HostContext';
-import { SettingsProvider } from './host/usePersistedSettings';
+import { useEffect, useState } from "react";
+import { FluentProvider } from "@fluentui/react-components";
+import { useStudioStyles } from "./primitives/styles";
+import { studioLight, studioDark, applyThemeAttr, type ThemeMode } from "./theme/theme";
+import { FrameHeader } from "./shell/FrameHeader";
+import { SaveContextRoot, type SaveContextValue } from "./state/SaveContext";
+import { findRequestType } from "./registry/requestTypes";
+import { RetrieveMultipleMode } from "./modes/RetrieveMultipleMode";
+import { RetrieveSingleMode } from "./modes/RetrieveSingleMode";
+import { RetrieveNextLinkMode } from "./modes/RetrieveNextLinkMode";
+import { PredefinedQueryMode } from "./modes/PredefinedQueryMode";
+import { CreateMode } from "./modes/CreateMode";
+import { UpdateMode } from "./modes/UpdateMode";
+import { UpsertMode } from "./modes/UpsertMode";
+import { DeleteMode } from "./modes/DeleteMode";
+import { MergeMode } from "./modes/MergeMode";
+import { AssociateMode } from "./modes/AssociateMode";
+import { DisassociateMode } from "./modes/DisassociateMode";
+import { ExecuteActionMode } from "./modes/ExecuteActionMode";
+import { ExecuteFunctionMode } from "./modes/ExecuteFunctionMode";
+import { ExecuteWorkflowMode } from "./modes/ExecuteWorkflowMode";
+import { ManageFileMode } from "./modes/ManageFileMode";
+import { ManageImageMode } from "./modes/ManageImageMode";
+import { ManageAttachmentMode } from "./modes/ManageAttachmentMode";
+import { StubMode } from "./modes/StubMode";
+import { findTable } from "./mock/metadata";
+import { _setTableLookup } from "./editors/filter/filterTree";
+import { HostProvider, useHostSession } from "./host/HostContext";
+import { SettingsProvider } from "./host/usePersistedSettings";
+import { OpenSettingsProvider } from "./host/useOpenSettings";
 
 // Wire metadata lookup into the filter-tree encoder (avoids a circular import).
 _setTableLookup(findTable);
 
 export function App() {
-  return (
-    <HostProvider>
-      <SettingsProvider>
-        <ThemedApp />
-      </SettingsProvider>
-    </HostProvider>
-  );
+	return (
+		<HostProvider>
+			<SettingsProvider>
+				<ThemedApp />
+			</SettingsProvider>
+		</HostProvider>
+	);
 }
 
 function ThemedApp() {
-  const host = useHostSession();
-  // Standalone mode: local toggle in the header controls theme.
-  // Embedded mode: host pushes the theme via `settings:updated` events; ignore the local toggle.
-  const [localTheme, setLocalTheme] = useState<ThemeMode>('light');
-  const themeMode: ThemeMode = host.embedded ? host.theme : localTheme;
-  const [activeId, setActiveId] = useState('retrieve-multiple');
+	const host = useHostSession();
+	// Standalone mode: local toggle in the header controls theme.
+	// Embedded mode: host pushes the theme via `settings:updated` events; ignore the local toggle.
+	const [localTheme, setLocalTheme] = useState<ThemeMode>("light");
+	const themeMode: ThemeMode = host.embedded ? host.theme : localTheme;
+	const [activeId, setActiveId] = useState("retrieve-multiple");
 
-  useEffect(() => { applyThemeAttr(themeMode); }, [themeMode]);
+	useEffect(() => {
+		applyThemeAttr(themeMode);
+	}, [themeMode]);
 
-  const fluentTheme = themeMode === 'dark' ? studioDark : studioLight;
+	const fluentTheme = themeMode === "dark" ? studioDark : studioLight;
 
-  return (
-    <FluentProvider theme={fluentTheme} style={{ height: '100vh' }}>
-      <Frame
-        themeMode={themeMode}
-        setThemeMode={setLocalTheme}
-        activeId={activeId}
-        setActiveId={setActiveId}
-      />
-    </FluentProvider>
-  );
+	return (
+		<FluentProvider theme={fluentTheme} style={{ height: "100vh" }}>
+			<OpenSettingsProvider>
+				<Frame
+					themeMode={themeMode}
+					setThemeMode={setLocalTheme}
+					activeId={activeId}
+					setActiveId={setActiveId}
+				/>
+			</OpenSettingsProvider>
+		</FluentProvider>
+	);
 }
 
-function Frame({ themeMode, setThemeMode, activeId, setActiveId }: {
-  themeMode: ThemeMode; setThemeMode: (m: ThemeMode) => void;
-  activeId: string; setActiveId: (id: string) => void;
+function Frame({
+	themeMode,
+	setThemeMode,
+	activeId,
+	setActiveId,
+}: {
+	themeMode: ThemeMode;
+	setThemeMode: (m: ThemeMode) => void;
+	activeId: string;
+	setActiveId: (id: string) => void;
 }) {
-  const s = useStudioStyles();
-  const type = findRequestType(activeId);
+	const s = useStudioStyles();
+	const type = findRequestType(activeId);
 
-  // Single slot for the currently-active mode's save context. The mode
-  // publishes via `usePublishSaveContext` and clears on unmount; the
-  // top-right Save button in FrameHeader reads via `useSaveContext`.
-  // Mounted ABOVE both so the bridge stays alive across mode switches.
-  const [saveCtx, setSaveCtx] = useState<SaveContextValue | null>(null);
+	// Single slot for the currently-active mode's save context. The mode
+	// publishes via `usePublishSaveContext` and clears on unmount; the
+	// top-right Save button in FrameHeader reads via `useSaveContext`.
+	// Mounted ABOVE both so the bridge stays alive across mode switches.
+	const [saveCtx, setSaveCtx] = useState<SaveContextValue | null>(null);
 
-  return (
-    // The active mode's group drives the v9 brand-color cascade defined
-    // in index.html. Every primary button,
-    // active tab underline, focus ring, and tinted background reads as the
-    // group color (green for Write, orange for Execute, etc.). The Read
-    // group keeps v9 defaults (blue), so we omit data-mode-group there.
-    <div
-      className={s.frame}
-      data-mode-group={type.group === 'read' ? undefined : type.group}
-    >
-      <SaveContextRoot value={saveCtx} setValue={setSaveCtx}>
-        <FrameHeader
-          themeMode={themeMode}
-          setThemeMode={setThemeMode}
-          activeId={activeId}
-          setActiveId={setActiveId}
-        />
-        {/* Every mode in the registry is now `implemented: true`, so the
+	return (
+		// The active mode's group drives the v9 brand-color cascade defined
+		// in index.html. Every primary button,
+		// active tab underline, focus ring, and tinted background reads as the
+		// group color (green for Write, orange for Execute, etc.). The Read
+		// group keeps v9 defaults (blue), so we omit data-mode-group there.
+		<div className={s.frame} data-mode-group={type.group === "read" ? undefined : type.group}>
+			<SaveContextRoot value={saveCtx} setValue={setSaveCtx}>
+				<FrameHeader
+					themeMode={themeMode}
+					setThemeMode={setThemeMode}
+					activeId={activeId}
+					setActiveId={setActiveId}
+				/>
+				{/* Every mode in the registry is now `implemented: true`, so the
             previous `__stub__` prefix detour
             was dead code. The default fallback (line below) still catches
             unknown IDs via StubMode. The `implemented` field is kept on the
             schema as a feature-flag for future modes added in WIP. */}
-        <ModeRouter modeId={activeId} themeMode={themeMode} setActiveId={setActiveId} />
-      </SaveContextRoot>
-    </div>
-  );
+				<ModeRouter modeId={activeId} themeMode={themeMode} setActiveId={setActiveId} />
+			</SaveContextRoot>
+		</div>
+	);
 }
 
-function ModeRouter({ modeId, themeMode, setActiveId }: {
-  modeId: string; themeMode: ThemeMode; setActiveId: (id: string) => void;
+function ModeRouter({
+	modeId,
+	themeMode,
+	setActiveId,
+}: {
+	modeId: string;
+	themeMode: ThemeMode;
+	setActiveId: (id: string) => void;
 }) {
-  switch (modeId) {
-    case 'retrieve-multiple': return <RetrieveMultipleMode themeMode={themeMode} />;
-    case 'retrieve-single':   return <RetrieveSingleMode   themeMode={themeMode} />;
-    case 'retrieve-nextlink': return <RetrieveNextLinkMode themeMode={themeMode} />;
-    case 'predefined-query':  return <PredefinedQueryMode  themeMode={themeMode} />;
-    case 'create':            return <CreateMode           themeMode={themeMode} />;
-    case 'update':            return <UpdateMode           themeMode={themeMode} />;
-    case 'upsert':            return <UpsertMode           themeMode={themeMode} />;
-    case 'delete':            return <DeleteMode           themeMode={themeMode} />;
-    case 'merge':             return <MergeMode            themeMode={themeMode} />;
-    case 'associate':         return <AssociateMode        themeMode={themeMode} />;
-    case 'disassociate':      return <DisassociateMode     themeMode={themeMode} />;
-    case 'exec-action':       return <ExecuteActionMode    themeMode={themeMode} category="oob" />;
-    case 'exec-customapi':    return <ExecuteActionMode    themeMode={themeMode} category="custom-api" />;
-    case 'exec-customaction': return <ExecuteActionMode    themeMode={themeMode} category="custom-action" />;
-    case 'exec-function':     return <ExecuteFunctionMode  themeMode={themeMode} />;
-    case 'exec-workflow':     return <ExecuteWorkflowMode  themeMode={themeMode} />;
-    case 'manage-file':       return <ManageFileMode       themeMode={themeMode} />;
-    case 'manage-image':      return <ManageImageMode      themeMode={themeMode} />;
-    case 'manage-attachment': return <ManageAttachmentMode themeMode={themeMode} />;
-    default:                  return <StubMode requestId={modeId} onPick={setActiveId} />;
-  }
+	switch (modeId) {
+		case "retrieve-multiple":
+			return <RetrieveMultipleMode themeMode={themeMode} />;
+		case "retrieve-single":
+			return <RetrieveSingleMode themeMode={themeMode} />;
+		case "retrieve-nextlink":
+			return <RetrieveNextLinkMode themeMode={themeMode} />;
+		case "predefined-query":
+			return <PredefinedQueryMode themeMode={themeMode} />;
+		case "create":
+			return <CreateMode themeMode={themeMode} />;
+		case "update":
+			return <UpdateMode themeMode={themeMode} />;
+		case "upsert":
+			return <UpsertMode themeMode={themeMode} />;
+		case "delete":
+			return <DeleteMode themeMode={themeMode} />;
+		case "merge":
+			return <MergeMode themeMode={themeMode} />;
+		case "associate":
+			return <AssociateMode themeMode={themeMode} />;
+		case "disassociate":
+			return <DisassociateMode themeMode={themeMode} />;
+		case "exec-action":
+			return <ExecuteActionMode themeMode={themeMode} category="oob" />;
+		case "exec-customapi":
+			return <ExecuteActionMode themeMode={themeMode} category="custom-api" />;
+		case "exec-customaction":
+			return <ExecuteActionMode themeMode={themeMode} category="custom-action" />;
+		case "exec-function":
+			return <ExecuteFunctionMode themeMode={themeMode} />;
+		case "exec-workflow":
+			return <ExecuteWorkflowMode themeMode={themeMode} />;
+		case "manage-file":
+			return <ManageFileMode themeMode={themeMode} />;
+		case "manage-image":
+			return <ManageImageMode themeMode={themeMode} />;
+		case "manage-attachment":
+			return <ManageAttachmentMode themeMode={themeMode} />;
+		default:
+			return <StubMode requestId={modeId} onPick={setActiveId} />;
+	}
 }

--- a/src/editors/TargetEditor.tsx
+++ b/src/editors/TargetEditor.tsx
@@ -1,211 +1,275 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from "react";
 import {
-  Field, Combobox, Option, Caption1, tokens, Body1, Spinner, Button,
-  type ComboboxProps,
-} from '@fluentui/react-components';
-import { Table20Filled, ArrowReset20Regular, ArrowSync20Regular } from '@fluentui/react-icons';
-import { PaneHead } from './PaneHead';
-import { findTable } from '../mock/metadata';
-import { useLiveTable } from '../host/useLiveMetadata';
-import { useScopedEntities } from '../host/useScopedEntities';
-import { RecordPicker } from '../primitives/RecordPicker';
-import { PasteODataDialog } from './PasteODataDialog';
-import { metadata } from '../host/metadataProvider';
-import type { RequestGroup } from '../registry/requestTypes';
-import type { ParsedRequest } from '../engine/odataParser';
+	Field,
+	Combobox,
+	Option,
+	Caption1,
+	tokens,
+	Body1,
+	Spinner,
+	Button,
+	MessageBar,
+	MessageBarBody,
+	MessageBarTitle,
+	MessageBarActions,
+	type ComboboxProps,
+} from "@fluentui/react-components";
+import {
+	Table20Filled,
+	ArrowReset20Regular,
+	ArrowSync20Regular,
+	Settings20Regular,
+} from "@fluentui/react-icons";
+import { PaneHead } from "./PaneHead";
+import { findTable } from "../mock/metadata";
+import { useLiveTable } from "../host/useLiveMetadata";
+import { useScopedEntities } from "../host/useScopedEntities";
+import { useOpenSettings } from "../host/useOpenSettings";
+import { RecordPicker } from "../primitives/RecordPicker";
+import { PasteODataDialog } from "./PasteODataDialog";
+import { metadata } from "../host/metadataProvider";
+import type { RequestGroup } from "../registry/requestTypes";
+import type { ParsedRequest } from "../engine/odataParser";
 
 export interface TargetEditorProps {
-  table: string;
-  onTableChange: (logicalName: string) => void;
-  /** If set, shows a record picker too (Retrieve Single) */
-  recordId?: string | null;
-  /**
-   * Called when the user picks (or clears) a record.
-   *
-   * `primary` is the resolved primary-name value of the picked record
-   * when known. For Search-mode picks it's always populated from the
-   * typeahead result. For GUID-paste picks (where no name has been
-   * resolved yet) it's an empty string — callers that need the name
-   * should fall back to fetching the row themselves.
-   */
-  onRecordChange?: (id: string | null, primary?: string) => void;
-  group?: RequestGroup;
-  /** Description line under the title */
-  sub?: string;
-  /**
-   * Reset every column-bound clause ($select / $filter / $orderby / $top /
-   * $expand / $apply / ...) to its empty default, BUT keep the current
-   * table. Surfaced as a "Reset request" button in the pane. Optional
-   * because not every mode wants it (e.g. ExecuteAction has no concept of
-   * a column-bound request).
-   */
-  onResetRequest?: () => void;
-  /**
-   * Apply a parsed OData URL to the mode's state. The mode receives the
-   * ParsedRequest and decides which fields to use. Optional for the same
-   * reason as onResetRequest.
-   */
-  onApplyParsed?: (parsed: ParsedRequest) => void;
+	table: string;
+	onTableChange: (logicalName: string) => void;
+	/** If set, shows a record picker too (Retrieve Single) */
+	recordId?: string | null;
+	/**
+	 * Called when the user picks (or clears) a record.
+	 *
+	 * `primary` is the resolved primary-name value of the picked record
+	 * when known. For Search-mode picks it's always populated from the
+	 * typeahead result. For GUID-paste picks (where no name has been
+	 * resolved yet) it's an empty string — callers that need the name
+	 * should fall back to fetching the row themselves.
+	 */
+	onRecordChange?: (id: string | null, primary?: string) => void;
+	group?: RequestGroup;
+	/** Description line under the title */
+	sub?: string;
+	/**
+	 * Reset every column-bound clause ($select / $filter / $orderby / $top /
+	 * $expand / $apply / ...) to its empty default, BUT keep the current
+	 * table. Surfaced as a "Reset request" button in the pane. Optional
+	 * because not every mode wants it (e.g. ExecuteAction has no concept of
+	 * a column-bound request).
+	 */
+	onResetRequest?: () => void;
+	/**
+	 * Apply a parsed OData URL to the mode's state. The mode receives the
+	 * ParsedRequest and decides which fields to use. Optional for the same
+	 * reason as onResetRequest.
+	 */
+	onApplyParsed?: (parsed: ParsedRequest) => void;
 }
 
 export function TargetEditor({
-  table, onTableChange, recordId, onRecordChange, group = 'read',
-  sub = 'Pick the entity set this request operates on.',
-  onResetRequest, onApplyParsed,
+	table,
+	onTableChange,
+	recordId,
+	onRecordChange,
+	group = "read",
+	sub = "Pick the entity set this request operates on.",
+	onResetRequest,
+	onApplyParsed,
 }: TargetEditorProps) {
-  const { entities, loading: entitiesLoading } = useScopedEntities();
-  const { loading: tableLoading } = useLiveTable(table || null);
-  const tbl = findTable(table);
-  const showRecord = onRecordChange !== undefined;
+	const { entities, loading: entitiesLoading, needsSetup, scopeMode } = useScopedEntities();
+	const openSettings = useOpenSettings();
+	const { loading: tableLoading } = useLiveTable(table || null);
+	const tbl = findTable(table);
+	const showRecord = onRecordChange !== undefined;
 
-  // Pure Fluent v9 Combobox pattern from the official storybook:
-  //   • controlled `value` for the typed input string
-  //   • `freeform` so the user can type without picking an option
-  //   • `clearable` for the native clear icon
-  //   • manual filter on the options list (Fluent v9 doesn't auto-filter)
-  // See https://storybooks.fluentui.dev/react/llms/components-combobox.txt
-  // — "Combobox with filtering" + "Clearable Combobox" sections.
-  const [value, setValue] = useState<string>(tbl?.displayName ?? '');
+	// Pure Fluent v9 Combobox pattern from the official storybook:
+	//   • controlled `value` for the typed input string
+	//   • `freeform` so the user can type without picking an option
+	//   • `clearable` for the native clear icon
+	//   • manual filter on the options list (Fluent v9 doesn't auto-filter)
+	// See https://storybooks.fluentui.dev/react/llms/components-combobox.txt
+	// — "Combobox with filtering" + "Clearable Combobox" sections.
+	const [value, setValue] = useState<string>(tbl?.displayName ?? "");
 
-  // Sync external selection → input text (happens after the metadata fetch
-  // resolves on initial load, or when a parent mode resets the table).
-  useEffect(() => {
-    setValue(tbl?.displayName ?? '');
-  }, [tbl?.displayName]);
+	// Sync external selection → input text (happens after the metadata fetch
+	// resolves on initial load, or when a parent mode resets the table).
+	useEffect(() => {
+		setValue(tbl?.displayName ?? "");
+	}, [tbl?.displayName]);
 
-  const matching = useMemo(() => {
-    const q = value.trim().toLowerCase();
-    if (!q) return entities;
-    return entities.filter(t =>
-      t.displayName.toLowerCase().includes(q) ||
-      t.logicalName.toLowerCase().includes(q) ||
-      t.entitySetName.toLowerCase().includes(q),
-    );
-  }, [entities, value]);
+	const matching = useMemo(() => {
+		const q = value.trim().toLowerCase();
+		if (!q) return entities;
+		return entities.filter(
+			(t) =>
+				t.displayName.toLowerCase().includes(q) ||
+				t.logicalName.toLowerCase().includes(q) ||
+				t.entitySetName.toLowerCase().includes(q),
+		);
+	}, [entities, value]);
 
-  const onChange: ComboboxProps['onChange'] = (e) => {
-    const next = (e.target as HTMLInputElement).value;
-    setValue(next);
-    // Clearing the input via the native `clearable` X also resets selection.
-    if (next === '' && table) onTableChange('');
-  };
+	const onChange: ComboboxProps["onChange"] = (e) => {
+		const next = (e.target as HTMLInputElement).value;
+		setValue(next);
+		// Clearing the input via the native `clearable` X also resets selection.
+		if (next === "" && table) onTableChange("");
+	};
 
-  const onOptionSelect: ComboboxProps['onOptionSelect'] = (_, d) => {
-    if (!d.optionValue) {
-      // The clearable X dispatches a no-option select — propagate clear.
-      onTableChange('');
-      setValue('');
-      return;
-    }
-    const sel = entities.find(t => t.logicalName === d.optionValue);
-    onTableChange(d.optionValue);
-    setValue(sel?.displayName ?? '');
-  };
+	const onOptionSelect: ComboboxProps["onOptionSelect"] = (_, d) => {
+		if (!d.optionValue) {
+			// The clearable X dispatches a no-option select — propagate clear.
+			onTableChange("");
+			setValue("");
+			return;
+		}
+		const sel = entities.find((t) => t.logicalName === d.optionValue);
+		onTableChange(d.optionValue);
+		setValue(sel?.displayName ?? "");
+	};
 
-  // Quick-action row — Refresh + Reset + Paste OData URL. Rendered only
-  // when the hosting mode supplies the callbacks (every column-bound
-  // retrieve mode does; specialty modes like ExecuteAction omit them).
-  const hasActions = !!onResetRequest || !!onApplyParsed;
+	// Quick-action row — Refresh + Reset + Paste OData URL. Rendered only
+	// when the hosting mode supplies the callbacks (every column-bound
+	// retrieve mode does; specialty modes like ExecuteAction omit them).
+	const hasActions = !!onResetRequest || !!onApplyParsed;
 
-  // Refresh metadata: nukes every cached entity/attribute/relationship
-  // record so the next read re-fetches with the current $select projection.
-  // Useful when (a) the user changed a column in the maker, (b) DRS rolled
-  // a new metadata-projection version (new flags appear after the cache
-  // is cleared), or (c) suspected stale data.
-  const onRefreshMetadata = () => {
-    metadata.invalidateAll();
-    // Re-warm the currently-selected entity so the user doesn't lose state.
-    if (table) void metadata.getTable(table);
-  };
+	// Refresh metadata: nukes every cached entity/attribute/relationship
+	// record so the next read re-fetches with the current $select projection.
+	// Useful when (a) the user changed a column in the maker, (b) DRS rolled
+	// a new metadata-projection version (new flags appear after the cache
+	// is cleared), or (c) suspected stale data.
+	const onRefreshMetadata = () => {
+		metadata.invalidateAll();
+		// Re-warm the currently-selected entity so the user doesn't lose state.
+		if (table) void metadata.getTable(table);
+	};
 
-  return (
-    <div>
-      <PaneHead icon={Table20Filled} title="Target" sub={sub} group={group}>
-        {hasActions && (
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-            {onApplyParsed && (
-              <PasteODataDialog onApply={onApplyParsed} />
-            )}
-            <Button
-              icon={<ArrowSync20Regular />}
-              appearance="outline"
-              size="small"
-              onClick={onRefreshMetadata}
-              title="Re-fetch every entity / attribute / relationship from Dataverse. Clears the in-memory metadata cache. Useful after editing the schema in the maker, or to pick up newly-added metadata flags."
-            >
-              Refresh metadata
-            </Button>
-            {onResetRequest && (
-              <Button
-                icon={<ArrowReset20Regular />}
-                appearance="outline"
-                size="small"
-                onClick={onResetRequest}
-                disabled={!table}
-                title="Clear $select / $filter / $orderby / $top / $expand / $apply while keeping the current table"
-              >
-                Reset request
-              </Button>
-            )}
-          </div>
-        )}
-      </PaneHead>
+	// Guidance banner — shown only after the entity list has finished loading
+	// AND settings indicate the scope is unconfigured. The loading gate prevents
+	// a flash for returning users whose persisted settings load async.
+	const setupHint =
+		scopeMode === "publisher-solution"
+			? "Open Settings → Query Scope and select a Publisher, then pick one or more Solutions to populate this list. Or switch the Entity Source to “All Entities”."
+			: "Open Settings → Query Scope and select one or more Solutions to populate this list. Or switch the Entity Source to “All Entities”.";
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 560 }}>
-        <Field
-          label="Table"
-          hint={tbl
-            ? `${tbl.entitySetName} · ${tbl.columns.length} columns${tableLoading ? ' · loading…' : ''}`
-            : entitiesLoading ? 'Loading entity list…' : `${entities.length} entities`}
-        >
-          <Combobox
-            freeform
-            clearable
-            value={value}
-            selectedOptions={table ? [table] : []}
-            onChange={onChange}
-            onOptionSelect={onOptionSelect}
-            placeholder={entitiesLoading ? 'Loading…' : 'Search tables by name…'}
-            listbox={{ style: { maxHeight: 360 } }}
-          >
-            {matching.length === 0 && (
-              <Option value="__none" text="" disabled>
-                <Caption1 style={{ color: tokens.colorNeutralForeground3 }}>
-                  No tables match "{value}"
-                </Caption1>
-              </Option>
-            )}
-            {matching.map(t => (
-              <Option key={t.logicalName} value={t.logicalName} text={t.displayName}>
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  <Body1>{t.displayName}</Body1>
-                  <Caption1 style={{ color: tokens.colorNeutralForeground3 }}>
-                    {t.entitySetName} · {t.logicalName}
-                  </Caption1>
-                </div>
-              </Option>
-            ))}
-          </Combobox>
-        </Field>
+	return (
+		<div>
+			{needsSetup && !entitiesLoading && (
+				<MessageBar
+					intent="warning"
+					style={{ marginBottom: tokens.spacingVerticalM, width: "100%" }}
+				>
+					<MessageBarBody>
+						<MessageBarTitle>Entity scope not configured</MessageBarTitle>
+						{setupHint}
+					</MessageBarBody>
+					<MessageBarActions
+						containerAction={
+							<Button
+								appearance="primary"
+								size="small"
+								icon={<Settings20Regular />}
+								onClick={openSettings}
+							>
+								Open Settings
+							</Button>
+						}
+					/>
+				</MessageBar>
+			)}
+			<PaneHead icon={Table20Filled} title="Target" sub={sub} group={group}>
+				{hasActions && (
+					<div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+						{onApplyParsed && <PasteODataDialog onApply={onApplyParsed} />}
+						<Button
+							icon={<ArrowSync20Regular />}
+							appearance="outline"
+							size="small"
+							onClick={onRefreshMetadata}
+							title="Re-fetch every entity / attribute / relationship from Dataverse. Clears the in-memory metadata cache. Useful after editing the schema in the maker, or to pick up newly-added metadata flags."
+						>
+							Refresh metadata
+						</Button>
+						{onResetRequest && (
+							<Button
+								icon={<ArrowReset20Regular />}
+								appearance="outline"
+								size="small"
+								onClick={onResetRequest}
+								disabled={!table}
+								title="Clear $select / $filter / $orderby / $top / $expand / $apply while keeping the current table"
+							>
+								Reset request
+							</Button>
+						)}
+					</div>
+				)}
+			</PaneHead>
 
-        {tableLoading && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: tokens.colorNeutralForeground3 }}>
-            <Spinner size="tiny" />
-            <Caption1>Fetching columns + relationships from Dataverse…</Caption1>
-          </div>
-        )}
+			<div style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 560 }}>
+				<Field
+					label="Table"
+					hint={
+						tbl
+							? `${tbl.entitySetName} · ${tbl.columns.length} columns${tableLoading ? " · loading…" : ""}`
+							: entitiesLoading
+								? "Loading entity list…"
+								: `${entities.length} entities`
+					}
+				>
+					<Combobox
+						freeform
+						clearable
+						value={value}
+						selectedOptions={table ? [table] : []}
+						onChange={onChange}
+						onOptionSelect={onOptionSelect}
+						placeholder={entitiesLoading ? "Loading…" : "Search tables by name…"}
+						listbox={{ style: { maxHeight: 360 } }}
+					>
+						{matching.length === 0 && (
+							<Option value="__none" text="" disabled>
+								<Caption1 style={{ color: tokens.colorNeutralForeground3 }}>
+									No tables match "{value}"
+								</Caption1>
+							</Option>
+						)}
+						{matching.map((t) => (
+							<Option key={t.logicalName} value={t.logicalName} text={t.displayName}>
+								<div style={{ display: "flex", flexDirection: "column" }}>
+									<Body1>{t.displayName}</Body1>
+									<Caption1 style={{ color: tokens.colorNeutralForeground3 }}>
+										{t.entitySetName} · {t.logicalName}
+									</Caption1>
+								</div>
+							</Option>
+						))}
+					</Combobox>
+				</Field>
 
-        {showRecord && tbl && (
-          <Field label="Record">
-            <RecordPicker
-              table={table}
-              selectedId={recordId ?? null}
-              onPick={r => onRecordChange?.(r?.id ?? null, r?.primary ?? '')}
-              placeholder={`Search ${tbl.displayName} records by ${tbl.primaryName}…`}
-            />
-          </Field>
-        )}
-      </div>
-    </div>
-  );
+				{tableLoading && (
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 8,
+							color: tokens.colorNeutralForeground3,
+						}}
+					>
+						<Spinner size="tiny" />
+						<Caption1>Fetching columns + relationships from Dataverse…</Caption1>
+					</div>
+				)}
+
+				{showRecord && tbl && (
+					<Field label="Record">
+						<RecordPicker
+							table={table}
+							selectedId={recordId ?? null}
+							onPick={(r) => onRecordChange?.(r?.id ?? null, r?.primary ?? "")}
+							placeholder={`Search ${tbl.displayName} records by ${tbl.primaryName}…`}
+						/>
+					</Field>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/src/host/useOpenSettings.tsx
+++ b/src/host/useOpenSettings.tsx
@@ -1,0 +1,52 @@
+// useOpenSettings — app-wide context that lets any component trigger the
+// Settings drawer without prop-drilling the open-state callback through
+// every mode → editor → primitive call chain.
+//
+// Pattern:
+//   1. Wrap the root tree in <OpenSettingsProvider>.
+//   2. FrameHeader calls `useRegisterOpenSettings(() => setSettingsOpen(true))`
+//      once it has its local open-state setter.
+//   3. Any deep component (e.g. TargetEditor) calls `useOpenSettings()` to
+//      get a stable `() => void` callback that opens the drawer.
+//
+// The registration uses a ref so the provider re-renders zero times when
+// FrameHeader mounts/unmounts.
+
+import { createContext, useCallback, useContext, useEffect, useRef, type ReactNode } from "react";
+
+type OpenFn = () => void;
+
+interface OpenSettingsCtx {
+	open: OpenFn;
+	register: (fn: OpenFn) => void;
+}
+
+const Ctx = createContext<OpenSettingsCtx | null>(null);
+
+export function OpenSettingsProvider({ children }: { children: ReactNode }) {
+	const ref = useRef<OpenFn | null>(null);
+
+	const open = useCallback(() => ref.current?.(), []);
+	const register = useCallback((fn: OpenFn) => {
+		ref.current = fn;
+	}, []);
+
+	return <Ctx.Provider value={{ open, register }}>{children}</Ctx.Provider>;
+}
+
+/** Call this in FrameHeader to register its local `setSettingsOpen(true)` callback. */
+export function useRegisterOpenSettings(fn: OpenFn) {
+	const ctx = useContext(Ctx);
+	useEffect(() => {
+		ctx?.register(fn);
+	}, [ctx, fn]);
+}
+
+/**
+ * Returns a stable `() => void` that opens the Settings drawer.
+ * Returns a no-op when called outside the provider (safe fallback).
+ */
+export function useOpenSettings(): OpenFn {
+	const ctx = useContext(Ctx);
+	return ctx?.open ?? (() => {});
+}

--- a/src/host/useScopedEntities.ts
+++ b/src/host/useScopedEntities.ts
@@ -13,99 +13,121 @@
 // We always start from the cached `loadAllEntities()` result — per-component
 // lookups never trigger a fresh entity metadata fetch.
 
-import { useEffect, useMemo, useState } from 'react';
-import {
-  getSolutionComponents,
-  filterCachedEntitiesByNames,
-} from './pptbClient';
-import { metadata, type EntityListItem } from './metadataProvider';
-import { metadataCache } from './cache';
-import { usePersistedSettings } from './usePersistedSettings';
+import { useEffect, useMemo, useState } from "react";
+import { getSolutionComponents, filterCachedEntitiesByNames } from "./pptbClient";
+import { metadata, type EntityListItem } from "./metadataProvider";
+import { metadataCache } from "./cache";
+import { usePersistedSettings } from "./usePersistedSettings";
 
 export interface UseScopedEntitiesResult {
-  entities: EntityListItem[];
-  loading: boolean;
-  error: string | null;
+	entities: EntityListItem[];
+	loading: boolean;
+	error: string | null;
+	/**
+	 * True when the entity list is empty because the user has not yet
+	 * configured the Query Scope in Settings (scoped mode with no solutions
+	 * selected). Used by TargetEditor to show a first-run guidance banner.
+	 * Always false when entityScopeMode === 'all'.
+	 */
+	needsSetup: boolean;
+	/** The active entityScopeMode — exposed so TargetEditor can tailor the hint. */
+	scopeMode: import("../state/displaySettings").EntityScopeMode;
 }
 
 export function useScopedEntities(): UseScopedEntitiesResult {
-  const [settings] = usePersistedSettings();
-  const [all, setAll] = useState<EntityListItem[]>([]);
-  const [allLoading, setAllLoading] = useState(true);
-  const [allError, setAllError] = useState<string | null>(null);
+	const [settings] = usePersistedSettings();
+	const [all, setAll] = useState<EntityListItem[]>([]);
+	const [allLoading, setAllLoading] = useState(true);
+	const [allError, setAllError] = useState<string | null>(null);
 
-  // ── Layer 1: unfiltered entity list ──
-  useEffect(() => {
-    let cancelled = false;
-    metadata.listEntities()
-      .then(list => { if (!cancelled) setAll(list); })
-      .catch(e => { if (!cancelled) setAllError(e instanceof Error ? e.message : String(e)); })
-      .finally(() => { if (!cancelled) setAllLoading(false); });
-    return () => { cancelled = true; };
-  }, []);
+	// ── Layer 1: unfiltered entity list ──
+	useEffect(() => {
+		let cancelled = false;
+		metadata
+			.listEntities()
+			.then((list) => {
+				if (!cancelled) setAll(list);
+			})
+			.catch((e) => {
+				if (!cancelled) setAllError(e instanceof Error ? e.message : String(e));
+			})
+			.finally(() => {
+				if (!cancelled) setAllLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
-  // ── Layer 2: solution-component cascade ──
-  const solutionKey = settings.selectedSolutionIds.join('|');
-  const [scopedNames, setScopedNames] = useState<string[] | null>(null);
-  const [scopedLoading, setScopedLoading] = useState(false);
-  const [scopedError, setScopedError] = useState<string | null>(null);
+	// ── Layer 2: solution-component cascade ──
+	const solutionKey = settings.selectedSolutionIds.join("|");
+	const [scopedNames, setScopedNames] = useState<string[] | null>(null);
+	const [scopedLoading, setScopedLoading] = useState(false);
+	const [scopedError, setScopedError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (settings.entityScopeMode === 'all') {
-      setScopedNames(null);
-      setScopedError(null);
-      return;
-    }
-    if (settings.selectedSolutionIds.length === 0) {
-      setScopedNames([]);
-      setScopedError(null);
-      return;
-    }
+	useEffect(() => {
+		if (settings.entityScopeMode === "all") {
+			setScopedNames(null);
+			setScopedError(null);
+			return;
+		}
+		if (settings.selectedSolutionIds.length === 0) {
+			setScopedNames([]);
+			setScopedError(null);
+			return;
+		}
 
-    let cancelled = false;
-    setScopedLoading(true);
-    setScopedError(null);
+		let cancelled = false;
+		setScopedLoading(true);
+		setScopedError(null);
 
-    // Cache hit → instant.
-    const cached = metadataCache.getFilteredEntities(settings.selectedSolutionIds);
-    if (cached) {
-      setScopedNames(cached.map(e => e.LogicalName));
-      setScopedLoading(false);
-      return;
-    }
+		// Cache hit → instant.
+		const cached = metadataCache.getFilteredEntities(settings.selectedSolutionIds);
+		if (cached) {
+			setScopedNames(cached.map((e) => e.LogicalName));
+			setScopedLoading(false);
+			return;
+		}
 
-    (async () => {
-      try {
-        const components = await getSolutionComponents(settings.selectedSolutionIds);
-        if (cancelled) return;
-        const names = Array.from(
-          new Set(components.map(c => c.msdyn_name).filter(Boolean)),
-        );
-        // Cache the filtered entity-meta list too so re-renders short-circuit.
-        const data = filterCachedEntitiesByNames(names);
-        metadataCache.setFilteredEntities(settings.selectedSolutionIds, data);
-        setScopedNames(names);
-      } catch (e) {
-        if (!cancelled) setScopedError(e instanceof Error ? e.message : String(e));
-      } finally {
-        if (!cancelled) setScopedLoading(false);
-      }
-    })();
-    return () => { cancelled = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settings.entityScopeMode, solutionKey]);
+		(async () => {
+			try {
+				const components = await getSolutionComponents(settings.selectedSolutionIds);
+				if (cancelled) return;
+				const names = Array.from(new Set(components.map((c) => c.msdyn_name).filter(Boolean)));
+				// Cache the filtered entity-meta list too so re-renders short-circuit.
+				const data = filterCachedEntitiesByNames(names);
+				metadataCache.setFilteredEntities(settings.selectedSolutionIds, data);
+				setScopedNames(names);
+			} catch (e) {
+				if (!cancelled) setScopedError(e instanceof Error ? e.message : String(e));
+			} finally {
+				if (!cancelled) setScopedLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [settings.entityScopeMode, solutionKey]);
 
-  // ── Compose visible list ──
-  const visible = useMemo(() => {
-    if (settings.entityScopeMode === 'all') return all;
-    if (scopedNames === null) return [];
-    const set = new Set(scopedNames);
-    return all.filter(e => set.has(e.logicalName));
-  }, [all, scopedNames, settings.entityScopeMode]);
+	// ── Compose visible list ──
+	const visible = useMemo(() => {
+		if (settings.entityScopeMode === "all") return all;
+		if (scopedNames === null) return [];
+		const set = new Set(scopedNames);
+		return all.filter((e) => set.has(e.logicalName));
+	}, [all, scopedNames, settings.entityScopeMode]);
 
-  return {
-    entities: visible,
-    loading: allLoading || scopedLoading,
-    error: allError ?? scopedError,
-  };
+	// needsSetup: scoped mode but no solutions chosen yet (entity list will be
+	// empty until the user configures Settings → Query Scope).
+	const needsSetup =
+		settings.entityScopeMode !== "all" && settings.selectedSolutionIds.length === 0;
+
+	return {
+		entities: visible,
+		loading: allLoading || scopedLoading,
+		error: allError ?? scopedError,
+		needsSetup,
+		scopeMode: settings.entityScopeMode,
+	};
 }

--- a/src/shell/FrameHeader.tsx
+++ b/src/shell/FrameHeader.tsx
@@ -1,143 +1,176 @@
-import { useState } from 'react';
+import { useState } from "react";
 import {
-  Breadcrumb, BreadcrumbButton, BreadcrumbDivider, BreadcrumbItem,
-  Button, Tooltip, ToolbarDivider, Menu, MenuTrigger, MenuPopover, MenuList, MenuItem, MenuDivider,
-  Badge, tokens,
-} from '@fluentui/react-components';
+	Breadcrumb,
+	BreadcrumbButton,
+	BreadcrumbDivider,
+	BreadcrumbItem,
+	Button,
+	Tooltip,
+	ToolbarDivider,
+	Menu,
+	MenuTrigger,
+	MenuPopover,
+	MenuList,
+	MenuItem,
+	MenuDivider,
+	Badge,
+	tokens,
+} from "@fluentui/react-components";
 import {
-  WeatherSunny20Regular, WeatherMoon20Regular, Share20Regular,
-  MoreHorizontal20Regular, Database20Regular, Settings20Regular,
-} from '@fluentui/react-icons';
-import { useStudioStyles } from '../primitives/styles';
-import { RequestTypePicker } from '../primitives/RequestTypePicker';
-import { SettingsDrawer } from './SettingsDrawer';
-import { usePersistedSettings } from '../host/usePersistedSettings';
-import { useAccessMode } from '../host/useAccessMode';
-import type { ThemeMode } from '../theme/theme';
-import { getEnv } from '../mock/environment';
-import { useHostSession } from '../host/HostContext';
-import { useSaveContext } from '../state/SaveContext';
-import { SaveButton, SavedLibraryButton } from '../editors/SavedRequestsDialog';
+	WeatherSunny20Regular,
+	WeatherMoon20Regular,
+	Share20Regular,
+	MoreHorizontal20Regular,
+	Database20Regular,
+	Settings20Regular,
+} from "@fluentui/react-icons";
+import { useStudioStyles } from "../primitives/styles";
+import { RequestTypePicker } from "../primitives/RequestTypePicker";
+import { SettingsDrawer } from "./SettingsDrawer";
+import { usePersistedSettings } from "../host/usePersistedSettings";
+import { useRegisterOpenSettings } from "../host/useOpenSettings";
+import { useAccessMode } from "../host/useAccessMode";
+import type { ThemeMode } from "../theme/theme";
+import { getEnv } from "../mock/environment";
+import { useHostSession } from "../host/HostContext";
+import { useSaveContext } from "../state/SaveContext";
+import { SaveButton, SavedLibraryButton } from "../editors/SavedRequestsDialog";
 
 export function FrameHeader({
-  themeMode, setThemeMode, activeId, setActiveId,
+	themeMode,
+	setThemeMode,
+	activeId,
+	setActiveId,
 }: {
-  themeMode: ThemeMode;
-  setThemeMode: (m: ThemeMode) => void;
-  activeId: string;
-  setActiveId: (id: string) => void;
+	themeMode: ThemeMode;
+	setThemeMode: (m: ThemeMode) => void;
+	activeId: string;
+	setActiveId: (id: string) => void;
 }) {
-  const s = useStudioStyles();
-  // PPTB owns the env switcher, the tool's chrome, and the theme toggle. Hide
-  // those affordances when embedded so we don't duplicate the host chrome — but
-  // keep them in standalone mode (the local dev experience needs them).
-  const host = useHostSession();
-  const embedded = host.embedded;
-  const env = getEnv();
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settings, updateSettings] = usePersistedSettings();
-  const { accessSummary } = useAccessMode();
-  // The current mode (if any) publishes its save context into the
-  // SaveContextRoot in App.tsx; we read it here so the top-right Save +
-  // Saved-library buttons drive that mode's persistence. If no mode is
-  // publishing (e.g. specialty modes with no persistable state), the
-  // buttons hide so the header doesn't carry inert chrome.
-  const saveCtx = useSaveContext();
-  return (
-    <header className={s.header}>
-      {!embedded && (
-        <>
-          <span className={s.brand} style={{ flexShrink: 0 }}>
-            <span className={s.brandDot} />
-            <span style={{ whiteSpace: 'nowrap' }}>Dataverse Request Studio</span>
-          </span>
-          <span style={{ color: tokens.colorNeutralForeground3, fontSize: 12, flexShrink: 0 }}>·</span>
-        </>
-      )}
-      <div style={{ display: 'flex', minWidth: 0, overflow: 'hidden', flexShrink: 1 }}>
-        <Breadcrumb size="small">
-          {!embedded && (
-            <>
-              <BreadcrumbItem><BreadcrumbButton>{env.name}</BreadcrumbButton></BreadcrumbItem>
-              <BreadcrumbDivider />
-            </>
-          )}
-          <BreadcrumbItem>
-            <RequestTypePicker activeId={activeId} onPick={setActiveId} />
-          </BreadcrumbItem>
-        </Breadcrumb>
-      </div>
-      <div className={s.spacer} />
-      {!embedded && (
-        <>
-          <Badge
-            appearance="ghost"
-            icon={<Database20Regular />}
-            style={{ flexShrink: 0, maxWidth: 280, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
-          >
-            {env.host}
-          </Badge>
-          <ToolbarDivider />
-          <Tooltip content={themeMode === 'dark' ? 'Switch to light' : 'Switch to dark'} relationship="label">
-            <Button
-              icon={themeMode === 'dark' ? <WeatherSunny20Regular /> : <WeatherMoon20Regular />}
-              appearance="subtle"
-              onClick={() => setThemeMode(themeMode === 'dark' ? 'light' : 'dark')}
-            />
-          </Tooltip>
-        </>
-      )}
-      {/* Save + Saved-library buttons — driven by the current mode's
+	const s = useStudioStyles();
+	// PPTB owns the env switcher, the tool's chrome, and the theme toggle. Hide
+	// those affordances when embedded so we don't duplicate the host chrome — but
+	// keep them in standalone mode (the local dev experience needs them).
+	const host = useHostSession();
+	const embedded = host.embedded;
+	const env = getEnv();
+	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [settings, updateSettings] = usePersistedSettings();
+	const { accessSummary } = useAccessMode();
+	// Register the open-settings callback so any component deep in the tree
+	// (e.g. TargetEditor's guidance banner) can open the drawer without prop-drilling.
+	useRegisterOpenSettings(() => setSettingsOpen(true));
+	// The current mode (if any) publishes its save context into the
+	// SaveContextRoot in App.tsx; we read it here so the top-right Save +
+	// Saved-library buttons drive that mode's persistence. If no mode is
+	// publishing (e.g. specialty modes with no persistable state), the
+	// buttons hide so the header doesn't carry inert chrome.
+	const saveCtx = useSaveContext();
+	return (
+		<header className={s.header}>
+			{!embedded && (
+				<>
+					<span className={s.brand} style={{ flexShrink: 0 }}>
+						<span className={s.brandDot} />
+						<span style={{ whiteSpace: "nowrap" }}>Dataverse Request Studio</span>
+					</span>
+					<span style={{ color: tokens.colorNeutralForeground3, fontSize: 12, flexShrink: 0 }}>
+						·
+					</span>
+				</>
+			)}
+			<div style={{ display: "flex", minWidth: 0, overflow: "hidden", flexShrink: 1 }}>
+				<Breadcrumb size="small">
+					{!embedded && (
+						<>
+							<BreadcrumbItem>
+								<BreadcrumbButton>{env.name}</BreadcrumbButton>
+							</BreadcrumbItem>
+							<BreadcrumbDivider />
+						</>
+					)}
+					<BreadcrumbItem>
+						<RequestTypePicker activeId={activeId} onPick={setActiveId} />
+					</BreadcrumbItem>
+				</Breadcrumb>
+			</div>
+			<div className={s.spacer} />
+			{!embedded && (
+				<>
+					<Badge
+						appearance="ghost"
+						icon={<Database20Regular />}
+						style={{
+							flexShrink: 0,
+							maxWidth: 280,
+							overflow: "hidden",
+							whiteSpace: "nowrap",
+							textOverflow: "ellipsis",
+						}}
+					>
+						{env.host}
+					</Badge>
+					<ToolbarDivider />
+					<Tooltip
+						content={themeMode === "dark" ? "Switch to light" : "Switch to dark"}
+						relationship="label"
+					>
+						<Button
+							icon={themeMode === "dark" ? <WeatherSunny20Regular /> : <WeatherMoon20Regular />}
+							appearance="subtle"
+							onClick={() => setThemeMode(themeMode === "dark" ? "light" : "dark")}
+						/>
+					</Tooltip>
+				</>
+			)}
+			{/* Save + Saved-library buttons — driven by the current mode's
           SaveContext. Hidden when no mode is publishing (e.g. legacy
           modes without persistable state). The Save button is dirty-
           aware (filled icon when there are unsaved changes, subtle
           when the in-memory state already matches a saved entry). */}
-      {saveCtx && (
-        <>
-          <SavedLibraryButton
-            modeId={saveCtx.modeId}
-            onLoad={saveCtx.onLoadSaved}
-            currentId={saveCtx.lastSavedId}
-          />
-          <SaveButton
-            state={saveCtx.state}
-            modeId={saveCtx.modeId}
-            dirty={saveCtx.dirty}
-            lastSavedId={saveCtx.lastSavedId}
-            onSaved={saveCtx.onSaved}
-          />
-        </>
-      )}
-      {!embedded && (
-        <Tooltip content="Share" relationship="label">
-          <Button icon={<Share20Regular />} appearance="subtle" />
-        </Tooltip>
-      )}
-      <Menu>
-        <MenuTrigger disableButtonEnhancement>
-          <Button icon={<MoreHorizontal20Regular />} appearance="subtle" />
-        </MenuTrigger>
-        <MenuPopover>
-          <MenuList>
-            <MenuItem>Duplicate request</MenuItem>
-            <MenuItem>Export OpenAPI</MenuItem>
-            <MenuDivider />
-            <MenuItem
-              icon={<Settings20Regular />}
-              onClick={() => setSettingsOpen(true)}
-            >
-              Settings
-            </MenuItem>
-          </MenuList>
-        </MenuPopover>
-      </Menu>
-      <SettingsDrawer
-        open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-        settings={settings}
-        onSettingsChange={updateSettings}
-        accessSummary={accessSummary}
-      />
-    </header>
-  );
+			{saveCtx && (
+				<>
+					<SavedLibraryButton
+						modeId={saveCtx.modeId}
+						onLoad={saveCtx.onLoadSaved}
+						currentId={saveCtx.lastSavedId}
+					/>
+					<SaveButton
+						state={saveCtx.state}
+						modeId={saveCtx.modeId}
+						dirty={saveCtx.dirty}
+						lastSavedId={saveCtx.lastSavedId}
+						onSaved={saveCtx.onSaved}
+					/>
+				</>
+			)}
+			{!embedded && (
+				<Tooltip content="Share" relationship="label">
+					<Button icon={<Share20Regular />} appearance="subtle" />
+				</Tooltip>
+			)}
+			<Menu>
+				<MenuTrigger disableButtonEnhancement>
+					<Button icon={<MoreHorizontal20Regular />} appearance="subtle" />
+				</MenuTrigger>
+				<MenuPopover>
+					<MenuList>
+						<MenuItem>Duplicate request</MenuItem>
+						<MenuItem>Export OpenAPI</MenuItem>
+						<MenuDivider />
+						<MenuItem icon={<Settings20Regular />} onClick={() => setSettingsOpen(true)}>
+							Settings
+						</MenuItem>
+					</MenuList>
+				</MenuPopover>
+			</Menu>
+			<SettingsDrawer
+				open={settingsOpen}
+				onClose={() => setSettingsOpen(false)}
+				settings={settings}
+				onSettingsChange={updateSettings}
+				accessSummary={accessSummary}
+			/>
+		</header>
+	);
 }


### PR DESCRIPTION
… (#29)

Closes #29

## What changed

### New: src/host/useOpenSettings.tsx
- OpenSettingsProvider wraps the FluentProvider tree in App.tsx
- useRegisterOpenSettings(fn) — called by FrameHeader to register its local setSettingsOpen(true) callback into the context
- useOpenSettings() — returns a stable () => void from any component in the tree; no-op fallback when called outside the provider
- Ref-based registration pattern: zero provider re-renders on mount/unmount

### Modified: src/App.tsx
- Wrap ThemedApp's FluentProvider tree in <OpenSettingsProvider> so the registered callback is available to every mode's component subtree

### Modified: src/shell/FrameHeader.tsx
- Call useRegisterOpenSettings(() => setSettingsOpen(true)) after the local settingsOpen state is declared, completing the wiring

### Modified: src/host/useScopedEntities.ts
- UseScopedEntitiesResult now exposes: needsSetup: boolean  -- true when entityScopeMode !== 'all' and selectedSolutionIds.length === 0 scopeMode: EntityScopeMode  -- active scope for hint text branching
- Computed once from persisted settings; zero extra fetches

### Modified: src/editors/TargetEditor.tsx
- Import MessageBar, MessageBarBody, MessageBarTitle, MessageBarActions, Settings20Regular, useOpenSettings
- Derive setupHint string from scopeMode (publisher-solution vs solution-only variants)
- Render a full-width warning MessageBar with 'Open Settings' primary button when needsSetup && !entitiesLoading
- Loading gate prevents flash for returning users whose persisted settings load async (settings always resolve before the entity fetch completes)
- Covers all 14 modes that use TargetEditor: RetrieveMultiple, RetrieveSingle, RetrieveNextLink, PredefinedQuery, Create, Update, Upsert, Delete, Merge, Associate, Disassociate, ManageFile, ManageImage, ManageAttachment

### Modified: CHANGELOG.md + package.json + npm-shrinkwrap.json
- Bump version 1.0.0 -> 1.1.0 (minor — new feature, no breaking changes)
- Document feature, new hook, useScopedEntities additions, and settings persistence namespace confirmation

## Design notes
- No dismiss cookie needed: the banner is purely reactive to persisted DisplaySettings. Once the user picks a publisher/solution (or switches to All Entities), needsSetup becomes false and the banner never shows again.
- Settings persist under pptb-dataverse-request-studio:displaySettings, distinct from FetchXML Studio and other PPTB tools. No changes needed.
- MessageBar width: 100% — fills the available main-pane viewport and shrinks/grows dynamically with window resize.

## Summary

What does this PR change and why?

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI / chore

## Affected mode(s)

If this PR touches one or more request modes, list them so reviewers know
where to focus regression testing:

- [x] Retrieve Multiple / Single / NextLink / Predefined Query
- [x] Create / Update / Upsert / Delete / Merge
- [x] Associate / Disassociate
- [x] Execute Action / Function / Workflow
- [x] Manage File / Image / Attachment
- [x] Cross-cutting (shell, settings, theme, etc.)
- [x] Not mode-specific

## How to test

Steps to validate the change end-to-end:

1. ...
2. ...

## Screenshots (if UI)

Before / After images or short recordings. Both **light AND dark** mode if
relevant.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm run build` is clean
- [x] No secrets included (tokens, client secrets, Authorization headers)
- [x] Accessibility considered (keyboard nav, focus rings, contrast)
- [x] `CHANGELOG.md` updated under `## [Unreleased]` (if user-facing)
- [x] Targeted at `dev`, not `main`
