### PR TITLE
fix(filter): resolve nav-path leaf columns against the related entity (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to Dataverse Request Studio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-06-08
+
+### 🐛 Fixed
+
+- **Custom OptionSet (and other typed) values incorrectly quoted as strings in
+  `$filter` over a lookup navigation** ([#33](https://github.com/mohsinonxrm/pptb-mxrm-dataverse-request-studio/issues/33)).
+  Filtering on a related-entity column via a nav path — e.g.
+  `msdyn_opportunityid/abc_salesstage eq 809770000` — emitted the value as a
+  quoted `Edm.String` (`'809770000'`), which Dataverse rejects with HTTP 500
+  / `0x80060888`. Standard columns appeared to work only by coincidence (the
+  root entity happened to own a same-named column). Root cause: the `$filter`
+  encoder resolved the leaf column against the **root** table instead of
+  walking the relationship to the **related** entity, so the leaf's
+  `AttributeType` never drove the quoting decision. The encoder now resolves
+  nav-path leaves against the correct related entity, so numeric/boolean/choice
+  types are emitted unquoted and strings/GUIDs are quoted, consistently.
+
+### ✨ Added / Changed (architecture)
+
+- **Single, metadata-driven nav-path resolver (`resolveNavPath`)** in
+  `mock/metadata.ts` — now the one source of truth for resolving a
+  slash-delimited path (`nav/.../leaf`, alias-aware) to its leaf `ColumnMeta`,
+  owner table, visited chain, and first not-yet-loaded hop. The `$filter`
+  encoder (`colLookup`), the filter editor's leaf/pending-target resolution,
+  and the `$orderby` warnings all route through it, eliminating duplicated
+  walk logic that had drifted out of sync.
+- **Related-entity metadata pre-warming (`useWarmReferencedTables`)** — the
+  Retrieve Multiple / Retrieve Single modes now walk the `$filter`, `$expand`,
+  `$apply`, and `$orderby` trees and pre-fetch the related entities they
+  reference. This makes correct type resolution independent of whether the
+  user opened the relevant editor — covering **saved-request reload**,
+  **pasted OData URLs**, and **direct Execute**. Targeted (only referenced
+  entities) and self-healing across multi-hop paths, so it stays clear of the
+  100-concurrent-request cap.
+- **Paste-OData parsing** now validates and pre-loads nav-path filter leaves
+  instead of skipping them.
+- **Metadata cache TTL raised from 5 minutes to 1 hour**, with a new
+  **Settings → Refresh metadata** button (`metadata.refreshAll`) to force a
+  fresh pull after publishing schema changes mid-session.
+
 ## [1.1.0] - 2026-05-25
 
 ### ✨ Added

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@mohsinonxrm/pptb-dataverse-request-studio",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mohsinonxrm/pptb-dataverse-request-studio",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mohsinonxrm/pptb-dataverse-request-studio",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/src/editors/OrderbyEditor.tsx
+++ b/src/editors/OrderbyEditor.tsx
@@ -6,7 +6,7 @@ import {
   Add20Regular, Delete20Regular, ArrowUp20Regular, ArrowDown20Regular,
 } from '@fluentui/react-icons';
 import { useStudioStyles } from '../primitives/styles';
-import { findTable, isCompanionLogicalReadOnly } from '../mock/metadata';
+import { findTable, isCompanionLogicalReadOnly, resolveNavPath } from '../mock/metadata';
 import { PaneHead } from './PaneHead';
 import { ApplyOverridesBanner } from './ApplyOverridesBanner';
 import { SortableList, SortableItem } from '../primitives/Sortable';
@@ -43,7 +43,7 @@ export function OrderbyEditor({ table, items, setItems, group = 'read', applyAct
   //  - Lookup/Customer/Owner: sorts by related row's primary name field (cross-table join)
   const warnings: string[] = [];
   for (const it of items) {
-    const c = tbl.columns.find(x => x.logicalName === it.col);
+    const c = resolveNavPath(tbl, it.col).leaf;
     if (!c) continue;
     if (c.attributeType === 'Picklist' || c.attributeType === 'State' || c.attributeType === 'Status') {
       warnings.push(`${c.displayName}: choice columns sort by the underlying integer value, not the localized label. Use FetchXml if you need label order.`);
@@ -60,7 +60,7 @@ export function OrderbyEditor({ table, items, setItems, group = 'read', applyAct
   }
   // Recommend a unique-key tie-breaker if no primary key is in the orderby
   const pkInSort = items.some(it => {
-    const c = tbl.columns.find(x => x.logicalName === it.col);
+    const c = resolveNavPath(tbl, it.col).leaf;
     return c?.attributeType === 'Uniqueidentifier';
   });
   if (items.length > 0 && !pkInSort) {
@@ -130,7 +130,7 @@ export function OrderbyEditor({ table, items, setItems, group = 'read', applyAct
           }}
         >
           {items.map((it, i) => {
-            const col = tbl.columns.find(c => c.logicalName === it.col);
+            const col = resolveNavPath(tbl, it.col).leaf;
             const itemId = it.id ?? `${it.col}-${i}`;
             // Grid columns: grip · row-number · column picker · sort-direction toggle · ↑ · ↓ · 🗑
             return (

--- a/src/editors/filter/FilterEditor.tsx
+++ b/src/editors/filter/FilterEditor.tsx
@@ -27,7 +27,7 @@ import {
 import { useStudioStyles } from '../../primitives/styles';
 import { groupColorVar } from '../../theme/theme';
 import { PaneHead } from '../PaneHead';
-import { findColumn, findTable, isCompanionLogicalReadOnly, type ColumnMeta, type TableMeta } from '../../mock/metadata';
+import { findColumn, findTable, isCompanionLogicalReadOnly, resolveNavPath, type ColumnMeta, type TableMeta } from '../../mock/metadata';
 import { useLiveTable } from '../../host/useLiveMetadata';
 import { ApplyOverridesBanner } from '../ApplyOverridesBanner';
 import {
@@ -59,22 +59,11 @@ function resolvePathLeaf(rootTable: TableMeta, path: string): {
   ownerTable?: TableMeta;
 } {
   if (!path) return {};
-  const segs = path.split('/');
-  let current: TableMeta | undefined = rootTable;
-  for (let i = 0; i < segs.length; i++) {
-    if (!current) return {};
-    const seg = segs[i];
-    if (i === segs.length - 1) {
-      return {
-        col: current.columns.find(c => c.logicalName === seg),
-        ownerTable: current,
-      };
-    }
-    const nav = current.navigationProperties.find(n => n.name === seg);
-    if (!nav) return {};
-    current = findTable(nav.targetEntity);
-  }
-  return {};
+  // Delegates to the canonical metadata-driven resolver (one source of truth
+  // shared with the $filter encoder, picker, and pre-warmer) so leaf type
+  // resolution is identical everywhere.
+  const r = resolveNavPath(rootTable, path);
+  return { col: r.leaf, ownerTable: r.ownerTable };
 }
 
 /** Convenience: just the leaf column. */
@@ -91,18 +80,10 @@ function resolvePathLeafColumn(rootTable: TableMeta, path: string): ColumnMeta |
  */
 function findPendingNavTarget(rootTable: TableMeta, path: string): string | null {
   if (!path || !path.includes('/')) return null;
-  const segs = path.split('/');
-  let current: TableMeta | undefined = rootTable;
-  // Skip the leaf segment (last one); only walk nav hops.
-  for (let i = 0; i < segs.length - 1; i++) {
-    if (!current) return null;
-    const nav = current.navigationProperties.find(n => n.name === segs[i]);
-    if (!nav) return null;
-    const target = findTable(nav.targetEntity);
-    if (!target) return nav.targetEntity;
-    current = target;
-  }
-  return null;
+  // Same canonical resolver — `pendingTarget` is the first nav hop whose
+  // entity isn't in the registry yet. Drives the per-row `useLiveTable` so a
+  // saved/pasted nav-path resolves level-by-level as targets load.
+  return resolveNavPath(rootTable, path).pendingTarget ?? null;
 }
 import type { RequestGroup } from '../../registry/requestTypes';
 

--- a/src/editors/filter/filterTree.ts
+++ b/src/editors/filter/filterTree.ts
@@ -11,6 +11,7 @@
 // Lambda nodes own their own nested FilterGroup.
 
 import type { ColumnMeta, TableMeta } from '../../mock/metadata';
+import { resolveNavPath } from '../../mock/metadata';
 import { findOperator, type OperatorDef } from './operators';
 import { attrRef } from '../../engine/odataAttr';
 // `Pick<>` here keeps the literal type narrow but allows ColumnMeta arity to widen
@@ -381,10 +382,17 @@ const arrayLiteral = (vals: string[]): string =>
   JSON.stringify(vals.map(v => String(v ?? '')));
 
 function colLookup(col: string, prefix: string | undefined, table: TableMeta): ColumnMeta | undefined {
-  // Strip lambda alias prefix (e.g. "c/jobtitle" → "jobtitle")
-  const stripped = prefix && col.startsWith(prefix + '/') ? col.slice(prefix.length + 1) : col;
-  const last = stripped.split('/').pop() ?? stripped;
-  return table.columns.find(c => c.logicalName === last);
+  // Resolve the leaf through the canonical metadata-driven resolver so a
+  // nav-path leaf (`msdyn_opportunityid/abc_salesstage`) is looked up on the
+  // RELATED entity, not the root. This is what makes the leaf's AttributeType
+  // drive quoting in `quoteLiteral` — fixing the custom-OptionSet "quoted as
+  // a string" bug (#33). `prefix` strips an enclosing lambda alias. For a bare
+  // column the resolver behaves exactly like the old root-table lookup.
+  //
+  // Returns undefined while a hop's metadata is still loading; the warm layer
+  // (`useWarmReferencedTables`) ensures referenced related entities are fetched
+  // so this resolves correctly by encode time, then re-renders.
+  return resolveNavPath(table, col, { alias: prefix }).leaf;
 }
 
 export interface EncodeCtx {

--- a/src/engine/navPath.ts
+++ b/src/engine/navPath.ts
@@ -1,0 +1,125 @@
+// navPath — request-tree reference discovery for metadata pre-warming.
+//
+// The $filter encoder (and the picker, antipattern scanner, etc.) resolve a
+// nav-path leaf's type against the RELATED entity's metadata (see
+// `resolveNavPath` in mock/metadata.ts). That only works if the related
+// entity has been fetched into the live registry. Today metadata is loaded
+// lazily — only when the user manually drills the column picker — so a request
+// that arrives fully-formed (saved-request reload, pasted OData URL, or a
+// direct Execute) can hit the encoder before the related entity is present,
+// and the leaf falls back to string-quoting (issue #33's failure mode).
+//
+// `collectReferencedEntities` walks a request's clause trees ($filter,
+// $expand, $apply, $orderby) and returns every RELATED entity logical name
+// referenced via a nav-path, lambda, or expand. The `useWarmReferencedTables`
+// hook feeds that list to `metadata.getTable` so the registry is warm before
+// the encoder runs — independent of whether any editor was ever opened.
+//
+// Resolution is lazy-aware and self-healing: a hop whose target isn't loaded
+// yet is still ADDED to the set (so it gets warmed), but the walk stops there
+// for this pass. Warming triggers a registry update; the hook re-runs and the
+// walk now reaches one level deeper. Repeats until the whole graph is warm.
+
+import { findTable, type TableMeta } from '../mock/metadata';
+import type { FilterGroup } from '../editors/filter/filterTree';
+import type { ExpandSpec } from '../editors/ExpandEditor';
+import type { OrderbySpec } from '../editors/OrderbyEditor';
+import type { ApplySpec } from '../editors/ApplyEditor';
+
+export interface ReferencedTreeInput {
+  filter?: FilterGroup;
+  expand?: ExpandSpec[];
+  apply?: ApplySpec;
+  orderby?: OrderbySpec[];
+}
+
+/**
+ * Add every related entity along a nav-path to `out`, walking N:1 hops as far
+ * as the registry currently resolves. `alias` strips an enclosing lambda
+ * alias. A bare column (no nav hop) contributes nothing.
+ */
+function addPathEntities(
+  table: TableMeta | undefined,
+  path: string,
+  out: Set<string>,
+  alias?: string,
+): void {
+  if (!table || !path) return;
+  let p = path;
+  if (alias && p.startsWith(alias + '/')) p = p.slice(alias.length + 1);
+  const segs = p.split('/').filter(Boolean);
+  let current: TableMeta | undefined = table;
+  for (let i = 0; i < segs.length - 1; i++) {
+    const nav = current?.navigationProperties.find(
+      n => n.name === segs[i] && n.cardinality === 'ManyToOne',
+    );
+    if (!nav) return;
+    out.add(nav.targetEntity);
+    current = findTable(nav.targetEntity); // undefined → warm it, resolve deeper next pass
+    if (!current) return;
+  }
+}
+
+/** Walk a $filter (or $apply pre-filter) tree, collecting nav + lambda targets. */
+function walkFilter(
+  group: FilterGroup,
+  table: TableMeta | undefined,
+  out: Set<string>,
+  alias?: string,
+): void {
+  if (!group) return;
+  for (const node of group.rules) {
+    if (node.type === 'rule' || node.type === 'function') {
+      if (node.col) addPathEntities(table, node.col, out, alias);
+    } else if (node.type === 'group') {
+      walkFilter(node, table, out, alias);
+    } else if (node.type === 'lambda') {
+      const nav = table?.navigationProperties.find(n => n.name === node.nav);
+      if (!nav) continue;
+      out.add(nav.targetEntity);
+      // Inner predicate is scoped to the lambda's target entity.
+      walkFilter(node.inner, findTable(nav.targetEntity), out, node.alias);
+    }
+  }
+}
+
+/** Walk a (possibly nested) $expand tree, collecting each target + inner clauses. */
+function walkExpand(
+  items: ExpandSpec[],
+  parentTable: TableMeta | undefined,
+  out: Set<string>,
+): void {
+  for (const it of items) {
+    const nav = parentTable?.navigationProperties.find(n => n.name === it.nav);
+    if (!nav) continue;
+    out.add(nav.targetEntity);
+    const target = findTable(nav.targetEntity);
+    if (it.filter) walkFilter(it.filter, target, out);
+    if (it.orderby) for (const o of it.orderby) addPathEntities(target, o.col, out);
+    if (it.nestedExpand) walkExpand(it.nestedExpand, target, out);
+  }
+}
+
+/**
+ * Return the related entity logical names referenced by a request's clause
+ * trees, resolvable against the current registry. The root table itself is
+ * excluded (it's loaded by the mode's own `useLiveTable`).
+ */
+export function collectReferencedEntities(
+  rootTableLogical: string,
+  input: ReferencedTreeInput,
+): string[] {
+  const root = findTable(rootTableLogical);
+  if (!root) return [];
+  const out = new Set<string>();
+
+  if (input.filter) walkFilter(input.filter, root, out);
+  if (input.apply?.prefilter) walkFilter(input.apply.prefilter, root, out);
+  if (input.apply?.groupby) for (const g of input.apply.groupby) addPathEntities(root, g, out);
+  if (input.apply?.aggregates) for (const a of input.apply.aggregates) addPathEntities(root, a.col, out);
+  if (input.orderby) for (const o of input.orderby) addPathEntities(root, o.col, out);
+  if (input.expand) walkExpand(input.expand, root, out);
+
+  out.delete(rootTableLogical);
+  return [...out];
+}

--- a/src/engine/odataParser.ts
+++ b/src/engine/odataParser.ts
@@ -31,7 +31,7 @@
 //   ⚠️ `$search`, `$format`, `$skiptoken` — Dataverse doesn't support these
 //      and DRS doesn't model them. Skipped silently.
 
-import type { TableMeta } from '../mock/metadata';
+import type { TableMeta, NavProperty } from '../mock/metadata';
 import { findTable } from '../mock/metadata';
 import type {
   FilterGroup, FilterNode, FilterRule, FilterFunctionNode, FilterLambdaNode,
@@ -381,8 +381,34 @@ async function validateFilterColumns(
       if (lambdaAlias && col.startsWith(lambdaAlias + '/')) {
         col = col.slice(lambdaAlias.length + 1);
       }
-      // Skip multi-segment nav-paths (e.g. `primarycontactid/fullname`)
-      if (col.includes('/')) continue;
+      // Multi-segment nav-path (e.g. `primarycontactid/abc_salesstage`):
+      // walk the N:1 hops, loading each related entity — which both validates
+      // the leaf AND warms the related metadata so the $filter encoder can
+      // resolve the leaf's type (and avoid string-quoting a numeric/boolean
+      // OptionSet — issue #33). Reported as a warning, not an error, because
+      // a hop may legitimately fail to load within the timeout.
+      if (col.includes('/')) {
+        const segs = col.split('/');
+        let cursor: TableMeta | undefined = ownerTable;
+        for (let i = 0; i < segs.length - 1; i++) {
+          if (!cursor) break;
+          const nav: NavProperty | undefined = cursor.navigationProperties.find(
+            (n: NavProperty) => n.name === segs[i] && n.cardinality === 'ManyToOne',
+          );
+          if (!nav) { cursor = undefined; break; }
+          cursor = await loadTableWithTimeout(loadTable, nav.targetEntity);
+        }
+        if (cursor) {
+          const leaf = segs[segs.length - 1];
+          if (!columnExistsOnTable(cursor, leaf)) {
+            warnings.push(iss(
+              `$filter: column \`${leaf}\` not found on \`${cursor.logicalName}\` (via \`${col}\`).`,
+              DOCS.filterRows,
+            ));
+          }
+        }
+        continue;
+      }
       if (!columnExistsOnTable(ownerTable, col)) {
         errors.push(iss(
           `$filter: column \`${col}\` does not exist on \`${ownerTable.logicalName}\`.`,

--- a/src/host/cache.ts
+++ b/src/host/cache.ts
@@ -8,7 +8,7 @@
 //                                          same key during a single fetch
 //   3. Fresh fetch                     →  cache + clear in-flight on resolve
 //
-// Stale-after-TTL means re-fetches kick in 5 minutes after the last write.
+// Stale-after-TTL means re-fetches kick in 1 hour after the last write.
 // Clear methods invalidate proactively (used by the "Refresh metadata"
 // button in Settings).
 //
@@ -28,7 +28,11 @@ interface CacheEntry<T> {
   timestamp: number;
 }
 
-const TTL_MS = 5 * 60 * 1000; // 5 minutes
+// 1 hour. Metadata (entities/attributes/relationships) changes rarely in a
+// released environment, so a long TTL keeps the tool snappy across a working
+// session. Users can force a fresh pull anytime via the Settings → "Refresh
+// metadata" button (metadata.refreshAll), which clears every cache entry.
+const TTL_MS = 60 * 60 * 1000; // 1 hour
 
 class MetadataCache {
   // ── Storage ─────────────────────────────────────────────────────────

--- a/src/host/metadataProvider.ts
+++ b/src/host/metadataProvider.ts
@@ -13,7 +13,7 @@
 // loaders short-circuit on cache hit.
 
 import * as loader from './dataverseMetadata';
-import { __registerLiveTable, findTable } from '../mock/metadata';
+import { __registerLiveTable, findTable, getLiveTables } from '../mock/metadata';
 import type {
   TableMeta, ColumnMeta, NavProperty, AlternateKeyDef,
   AttributeTypeCode, SourceType,
@@ -41,8 +41,15 @@ export interface MetadataProvider {
   peekTable(logical: string): TableMeta | undefined;
   /** Invalidate one table; the next read refetches. */
   invalidateTable(logical: string): void;
-  /** Nuke all caches. Wired to the "Refresh metadata" button. */
+  /** Nuke all caches + the live registry. The next read refetches. */
   invalidateAll(): void;
+  /**
+   * Refresh in place: drop caches, then re-fetch every currently-registered
+   * table and re-publish it. Unlike `invalidateAll`, editors keep showing the
+   * (briefly stale) current data until fresh data lands, with no need to
+   * re-navigate. Wired to the Settings "Refresh metadata" button.
+   */
+  refreshAll(): Promise<void>;
 }
 
 // ── Raw → studio-shape mappers ─────────────────────────────────────────
@@ -377,5 +384,19 @@ export const metadata: MetadataProvider = {
     // The next mode-level `useLiveTable` fetch will repopulate.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     import('../mock/metadata').then(({ __clearLiveTables }) => __clearLiveTables());
+  },
+
+  async refreshAll(): Promise<void> {
+    // Snapshot what's currently registered, drop caches, then rebuild each
+    // table. `buildTable` always hits the network (cache just cleared) and
+    // re-registers via `__registerLiveTable`, firing the registry listeners
+    // so every editor re-renders with fresh data. We deliberately do NOT
+    // clear the registry first, so the UI shows current data until each
+    // table's refresh lands. The set is small (current target + warmed
+    // related entities), keeping us clear of the 100-concurrent cap.
+    const logicals = getLiveTables().map(t => t.logicalName);
+    metadataCache.clear();
+    buildInFlight = new Map();
+    await Promise.all(logicals.map(l => buildTable(l)));
   },
 };

--- a/src/host/useLiveMetadata.ts
+++ b/src/host/useLiveMetadata.ts
@@ -11,11 +11,12 @@
 //   - `useLiveTable(logical)` — fires `metadata.getTable(logical)` + subscribes.
 //   - `useLiveEntities()` — `metadata.listEntities()`, returns EntityListItem[].
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { metadata, type EntityListItem } from './metadataProvider';
 import {
   __subscribeLiveTables, findTable, type TableMeta,
 } from '../mock/metadata';
+import { collectReferencedEntities, type ReferencedTreeInput } from '../engine/navPath';
 
 /**
  * Returns the TableMeta for a logical name. On mount/change it fires the
@@ -89,3 +90,45 @@ export function useWarmTable(): (logical: string) => Promise<void> {
 // 100-concurrent-request cap on wide entities. Editors now load the
 // *selected* target only via `useLiveTable(name)`. Display labels for
 // non-loaded targets gracefully fall back to the raw logical name.
+
+/**
+ * Pre-warm the RELATED entities a request actually references via nav-paths,
+ * lambdas, and $expand — so the $filter/$apply/$expand encoders resolve leaf
+ * column TYPES against the correct entity (issue #33) even when the request
+ * arrives fully-formed (saved-request reload, pasted OData URL, or a direct
+ * Execute) and no editor was ever opened to lazily trigger the loads.
+ *
+ * Targeted, not bulk: only the handful of entities the request mentions are
+ * fetched (`metadata.getTable` dedupes + caches), so this stays well clear of
+ * the 100-concurrent-request cap that motivated removing `useWarmTables`.
+ *
+ * Self-healing across hops: the walk only reaches as deep as the registry is
+ * currently warm. Each fetch fires a registry update, which re-runs this hook
+ * and lets the walk reach one level deeper, until the whole referenced graph
+ * is present. Failures are swallowed (best-effort warming; the editors still
+ * render with whatever metadata is available).
+ */
+export function useWarmReferencedTables(
+  rootTable: string | null | undefined,
+  trees: ReferencedTreeInput,
+): void {
+  const [registryVersion, setRegistryVersion] = useState(0);
+  useEffect(() => __subscribeLiveTables(() => setRegistryVersion(v => v + 1)), []);
+
+  // Stable dependency key — the trees object is rebuilt by the caller each
+  // render, so depend on its serialized content rather than its identity.
+  const treeKey = useMemo(
+    () => JSON.stringify([trees.filter, trees.expand, trees.apply, trees.orderby]),
+    [trees.filter, trees.expand, trees.apply, trees.orderby],
+  );
+
+  useEffect(() => {
+    if (!rootTable) return;
+    for (const name of collectReferencedEntities(rootTable, trees)) {
+      if (!findTable(name)) void metadata.getTable(name).catch(() => {});
+    }
+    // `trees` is read via the stable `treeKey`; `registryVersion` re-runs the
+    // walk as deeper hops become resolvable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootTable, treeKey, registryVersion]);
+}

--- a/src/mock/metadata.ts
+++ b/src/mock/metadata.ts
@@ -486,6 +486,87 @@ export const findTable = (logicalName: string): TableMeta | undefined =>
 export const findColumn = (table: TableMeta, logicalName: string): ColumnMeta | undefined =>
   table.columns.find(c => c.logicalName === logicalName);
 
+// ══════════════════════════════════════════════════════════════════════
+// Canonical nav-path resolver — SINGLE SOURCE OF TRUTH.
+// ══════════════════════════════════════════════════════════════════════
+//
+// A "nav-path" is a slash-delimited column reference that walks one or more
+// single-valued (N:1) navigation properties to reach a column on a RELATED
+// entity — e.g. `msdyn_opportunityid/abc_salesstage` or the chained form
+// `primarycontactid/createdby/fullname`. The convention is: every segment
+// EXCEPT the last is a nav property; the last segment is the leaf column.
+//
+// Before this resolver existed, the same walk was reimplemented in ~5 places
+// (FilterEditor, NavPathColumnPicker, antipatterns, columnDisplayMap, the
+// lambda encoder) and — critically — was MISSING from the $filter encoder's
+// `colLookup`, which resolved the leaf against the ROOT table only. That made
+// the encoder serialise a related-entity custom OptionSet (Edm.Int32) as a
+// quoted string, which Dataverse rejects with 0x80060888 (issue #33). Routing
+// every committed-path resolution through this one function makes the leaf's
+// AttributeType drive quoting everywhere, consistently.
+//
+// Resolution is metadata-driven and lazy-aware: each hop is looked up in the
+// live registry via `findTable`. If a related entity hasn't been fetched yet,
+// `pendingTarget` names the first missing entity so callers can trigger a load
+// (`useWarmReferencedTables` / `useLiveTable`) and re-resolve on the next
+// render. This is the same self-healing contract the lambda encoder relies on.
+
+export interface ResolvedNavPath {
+  /** The resolved leaf column, on the deepest entity. Undefined when the
+   *  path can't be fully resolved (bad segment, or a hop not yet loaded). */
+  leaf?: ColumnMeta;
+  /** The entity the leaf lives on (the deepest entity walked). For a bare
+   *  column this is the root table. */
+  ownerTable?: TableMeta;
+  /** Entities visited, starting with the root: `[root, …related]`. */
+  chain: TableMeta[];
+  /** Logical name of the first nav target NOT yet in the live registry, if
+   *  any. Drives lazy-loading; undefined once the whole chain is resolvable. */
+  pendingTarget?: string;
+}
+
+/**
+ * Resolve a (possibly aliased) nav-path against `rootTable`, walking N:1
+ * navigation properties through the live registry.
+ *
+ * @param rootTable the entity the path is anchored on (root, or a lambda's
+ *   target entity when resolving inside a lambda predicate).
+ * @param path      slash-delimited path: `col` | `nav/col` | `nav/nav/col`.
+ * @param opts.alias a lambda alias to strip from the head (e.g. `c` strips
+ *   `c/jobtitle` → `jobtitle`, `c/primarycontactid/name` →
+ *   `primarycontactid/name`).
+ */
+export function resolveNavPath(
+  rootTable: TableMeta | undefined,
+  path: string,
+  opts?: { alias?: string },
+): ResolvedNavPath {
+  if (!rootTable) return { chain: [] };
+  let p = path;
+  const alias = opts?.alias;
+  if (alias && p.startsWith(alias + '/')) p = p.slice(alias.length + 1);
+  const segs = p.split('/').filter(Boolean);
+  const chain: TableMeta[] = [rootTable];
+  if (segs.length === 0) return { ownerTable: rootTable, chain };
+
+  let current: TableMeta = rootTable;
+  // Walk every segment except the leaf as an N:1 nav hop.
+  for (let i = 0; i < segs.length - 1; i++) {
+    const nav = current.navigationProperties.find(
+      n => n.name === segs[i] && n.cardinality === 'ManyToOne',
+    );
+    // Unknown nav segment — can't go deeper; report what we have.
+    if (!nav) return { ownerTable: current, chain };
+    const target = findTable(nav.targetEntity);
+    // Target not loaded yet — surface it for lazy-loading + re-resolve later.
+    if (!target) return { ownerTable: current, chain, pendingTarget: nav.targetEntity };
+    chain.push(target);
+    current = target;
+  }
+  const leafSeg = segs[segs.length - 1];
+  return { leaf: current.columns.find(c => c.logicalName === leafSeg), ownerTable: current, chain };
+}
+
 /**
  * Predicate that hides "companion" read-only logical columns from picker
  * UIs. These are the denormalized `*name` / `*yominame` / `*codename` text

--- a/src/modes/RetrieveMultipleMode.tsx
+++ b/src/modes/RetrieveMultipleMode.tsx
@@ -48,7 +48,7 @@ import type { ThemeMode } from '../theme/theme';
 // Live-metadata hook: subscribes to the registry so child editors
 // (SelectEditor, FilterEditor, OrderbyEditor, ExpandEditor, lambdas)
 // re-render when columns + relationships land from Dataverse.
-import { useLiveTable } from '../host/useLiveMetadata';
+import { useLiveTable, useWarmReferencedTables } from '../host/useLiveMetadata';
 import { useScopedEntities } from '../host/useScopedEntities';
 
 // Empty initial state — the studio is a request *builder*; seeding it with
@@ -110,6 +110,17 @@ export function RetrieveMultipleMode({ themeMode }: { themeMode: ThemeMode }) {
   // The hook intentionally returns nothing we use here; its side effect
   // (subscription + warming) is the point.
   useLiveTable(state.table || null);
+  // Pre-warm RELATED entities referenced by nav-path filters / lambdas /
+  // $expand / $apply / $orderby so the encoders resolve leaf column TYPES
+  // against the correct entity (issue #33) — even on saved-request reload,
+  // pasted-URL apply, or a direct Execute where no editor was opened to
+  // lazily trigger the loads.
+  useWarmReferencedTables(state.table || null, {
+    filter: state.filter,
+    expand: state.expand,
+    apply: state.apply,
+    orderby: state.orderby,
+  });
   // Entity list — used to validate saved-request loads against the
   // current org (block load if the entity has been uninstalled).
   const { entities } = useScopedEntities();

--- a/src/modes/RetrieveSingleMode.tsx
+++ b/src/modes/RetrieveSingleMode.tsx
@@ -49,7 +49,7 @@ import { runtime, type ExecResult } from '../engine/runtime';
 import type { ExpandSpec } from '../editors/ExpandEditor';
 import type { RetrieveSingleState, RecentRun } from '../state/readState';
 import type { ThemeMode } from '../theme/theme';
-import { useLiveTable } from '../host/useLiveMetadata';
+import { useLiveTable, useWarmReferencedTables } from '../host/useLiveMetadata';
 import { useScopedEntities } from '../host/useScopedEntities';
 import {
   serializeRetrieveSingle, hashState, deserializeRetrieveSingle,
@@ -79,6 +79,10 @@ export function RetrieveSingleMode({ themeMode }: { themeMode: ThemeMode }) {
   const [state, setState] = useState(initialState);
   // Live-metadata subscription so child editors re-render when columns/relationships land.
   useLiveTable(state.table || null);
+  // Pre-warm entities referenced by nested $expand (inner $select/$filter/
+  // $orderby) so encoders resolve against the right related entity — even on
+  // saved-request reload / pasted URL where no expand editor was opened.
+  useWarmReferencedTables(state.table || null, { expand: state.expand });
   const { entities } = useScopedEntities();
   const [activePath, setActivePath] = useState<string>('target');
   const [tab, setTab] = useState<MainTab>('builder');

--- a/src/shell/SettingsDrawer.tsx
+++ b/src/shell/SettingsDrawer.tsx
@@ -26,11 +26,12 @@ import {
   TagPicker, TagPickerControl, TagPickerGroup, TagPickerInput,
   TagPickerList, TagPickerOption, useTagPickerFilter, Tag,
 } from '@fluentui/react-components';
-import { Dismiss24Regular, Settings20Regular, Info16Regular } from '@fluentui/react-icons';
+import { Dismiss24Regular, Settings20Regular, Info16Regular, ArrowClockwise20Regular } from '@fluentui/react-icons';
 import type {
   DisplaySettings, ValueDisplayMode, EntityScopeMode,
 } from '../state/displaySettings';
 import type { AccessSummary } from '../host/pptbClient';
+import { metadata } from '../host/metadataProvider';
 import { usePublisherFilter } from '../host/usePublisherFilter';
 import { useSolutionFilter } from '../host/useSolutionFilter';
 
@@ -116,6 +117,17 @@ export function SettingsDrawer({
   const handleSolutionIdsChange = useCallback((ids: string[]) => {
     onSettingsChange({ ...settings, selectedSolutionIds: ids });
   }, [settings, onSettingsChange]);
+
+  // Refresh metadata — drops every cache entry and re-fetches the
+  // currently-loaded tables in place. Used when entity/attribute/relationship
+  // definitions change in the environment mid-session (the cache TTL is 1h).
+  const [refreshing, setRefreshing] = useState(false);
+  const handleRefreshMetadata = useCallback(async () => {
+    setRefreshing(true);
+    try { await metadata.refreshAll(); }
+    catch (e) { console.warn('[SettingsDrawer] refresh metadata failed', e); }
+    finally { setRefreshing(false); }
+  }, []);
 
   // Privilege gating — when AccessSummary hasn't loaded yet we allow all
   // options (deferred validation).
@@ -284,6 +296,32 @@ export function SettingsDrawer({
               <Option value="raw">Raw</Option>
               <Option value="both">Both (2 columns per attribute)</Option>
             </Dropdown>
+          </div>
+        </div>
+
+        <Divider />
+
+        {/* ── Section: Metadata ────────────────────────────────── */}
+        <div className={styles.section} style={{ marginTop: tokens.spacingVerticalL }}>
+          <Text className={styles.sectionTitle}>Metadata</Text>
+
+          <div className={styles.settingItem}>
+            <Text className={styles.settingLabel}>Refresh metadata</Text>
+            <Text className={styles.settingDescription} block style={{ marginBottom: tokens.spacingVerticalS }}>
+              Re-fetch entity, attribute &amp; relationship definitions from the
+              environment. Use this after publishing schema changes — metadata is
+              otherwise cached for up to an hour.
+            </Text>
+            <Button
+              appearance="outline"
+              size="small"
+              icon={refreshing ? <Spinner size="tiny" /> : <ArrowClockwise20Regular />}
+              disabled={refreshing}
+              onClick={handleRefreshMetadata}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              {refreshing ? 'Refreshing…' : 'Refresh metadata'}
+            </Button>
           </div>
         </div>
       </DrawerBody>


### PR DESCRIPTION
Closes #33

## Problem
Filtering on a related-entity column via a lookup navigation — e.g. `msdyn_opportunityid/abc_salesstage eq 809770000` — emitted the value as a quoted `Edm.String` (`'809770000'`), which Dataverse rejects with **HTTP 500 / `0x80060888`**. Standard OptionSets *appeared* to work, but only by coincidence (the root entity happened to own a same-named column).

## Root cause
This is **not** a metadata-fetch gap (the picker already resolves related-entity types correctly). The `$filter` **encoder** resolved the leaf column against the **root** table only (`colLookup` in `filterTree.ts`). For a nav-path leaf that lives on the related entity, resolution returned `undefined`, so `quoteLiteral` fell back to string-quoting — the leaf's `AttributeType` never drove the quoting decision.

There was also a deeper **availability** gap: even with correct walking, the encoder reads the synchronous registry, which is only populated when the user manually drills the column picker. So saved-request reload, pasted OData URLs, and direct Execute could encode before related metadata was present.

## Fix (designed, not patched)
- **Single source of truth** — new metadata-driven `resolveNavPath()` in `mock/metadata.ts`. The `$filter` encoder (`colLookup`), the filter editor's leaf/pending-target resolution, and `$orderby` warnings all route through it, removing duplicated walk logic that had drifted apart.
- **Pre-warming** — new `useWarmReferencedTables()` hook: Retrieve Multiple / Single walk the `$filter`/`$expand`/`$apply`/`$orderby` trees and pre-fetch referenced related entities. Makes correct type resolution independent of which editor was opened — covers **saved-request reload**, **pasted OData URLs**, and **direct Execute**. Targeted + self-healing across multi-hop paths, so it stays clear of the 100-concurrent-request cap.
- **Parser** — `odataParser` now validates and pre-loads nav-path filter leaves instead of skipping them.
- **Cache** — TTL raised 5 min → 1 h, plus a **Settings → Refresh metadata** button (`metadata.refreshAll`) for mid-session schema changes.

## Scope / safety
- Bare-column resolution is byte-for-byte unchanged; string/GUID leaves still quote correctly.
- The 16 non-read modes have no `$filter`/`$expand` trees → no-ops, no risk.
- LHS bonus: nav-path leaves that are themselves lookups now correctly emit `_x_value`.

## Verification
- `npm run typecheck` ✅  `npm run build` ✅
- Manually validated against account/contact/opportunity OOB nav-paths (e.g. `accounts?$filter=primarycontactid/familystatuscode eq 1` → unquoted, 200), chained 2-hop paths, save→reload→direct-execute, paste→execute, `$expand` inner filter, `$apply` pre-filter, and bare-column regressions.

Bumps `1.1.0` → `1.1.1`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)