### PR TITLE
fix(metadata): address PR #35 review feedback — v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to Dataverse Request Studio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-06-08
+
+### 🐛 Fixed
+
+- **`refreshAll()` race condition** (`metadataProvider.ts`) — the Settings
+  "Refresh metadata" button now drains any in-flight `buildTable` promises via
+  `Promise.allSettled` before clearing the cache. Previously an orphaned fetch
+  that settled after the clear could call `__registerLiveTable` with
+  pre-refresh data, silently overwriting the fresh registration.
+
+- **Silent bad-hop in OData parse validation** (`odataParser.ts`) — when the
+  parser walks a nav-path `$filter` column and encounters an unknown or
+  non-ManyToOne navigation segment, it now emits an actionable warning (naming
+  the bad segment and its owner table) instead of silently skipping validation.
+  A separate warning is emitted when the related entity's metadata times out
+  during the walk.
+
+- **`resolveNavPath` leaf lookup now matches `oDataName`** (`mock/metadata.ts`)
+  — the leaf-column search now also checks `ColumnMeta.oDataName` (e.g.
+  `_primarycontactid_value`) in addition to `logicalName`. This closes a gap
+  where a round-tripped or pasted OData `$filter` that preserved the lookup
+  wire form as the path leaf would resolve to `undefined`, causing the `$filter`
+  encoder to fall back to string-quoting a value that should be unquoted
+  (GUID / integer).
+
 ## [1.1.1] - 2026-06-08
 
 ### 🐛 Fixed

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,3815 +1,3815 @@
 {
-  "name": "@mohsinonxrm/pptb-dataverse-request-studio",
-  "version": "1.1.1",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "@mohsinonxrm/pptb-dataverse-request-studio",
-      "version": "1.1.1",
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^10.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
-        "@fluentui-contrib/react-data-grid-react-window": "^1.4.2",
-        "@fluentui/react-components": "^9.73.8",
-        "@fluentui/react-datepicker-compat": "^0.6.31",
-        "@fluentui/react-icons": "^2.0.326",
-        "@fluentui/react-timepicker-compat": "^0.4.34",
-        "@monaco-editor/react": "^4.7.0",
-        "monaco-editor": "^0.54.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "devDependencies": {
-        "@pptb/types": "^1.2.1",
-        "@types/react": "^18.3.28",
-        "@types/react-dom": "^18.3.7",
-        "@vitejs/plugin-react": "^5.2.0",
-        "typescript": "~5.9.3",
-        "vite": "^7.3.3"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@ctrl/tinycolor": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
-      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@dnd-kit/accessibility": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
-      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
-      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/accessibility": "^3.1.1",
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/sortable": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
-      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.3.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT"
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/devtools": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.3.tgz",
-      "integrity": "sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
-    },
-    "node_modules/@fluentui-contrib/react-data-grid-react-window": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-data-grid-react-window/-/react-data-grid-react-window-1.4.2.tgz",
-      "integrity": "sha512-pYPa6pgKlDpfUybMExfk8UifAJV+p6eAmjpS4l2iLBDLOaY41YHtKO8IEaNe3ogISJuEWmJFCPUa5LIzlXQxhw==",
-      "license": "MIT",
-      "dependencies": {
-        "@swc/helpers": "~0.5.11",
-        "react-window": "^1.8.5"
-      },
-      "peerDependencies": {
-        "@fluentui/react-components": ">=9.70.0 <10.0.0",
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/keyboard-keys": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
-      "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
-      "license": "MIT",
-      "dependencies": {
-        "@swc/helpers": "^0.5.1"
-      }
-    },
-    "node_modules/@fluentui/priority-overflow": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.3.0.tgz",
-      "integrity": "sha512-yaBC0R4e+4ZlCWDulB5S+xBrlnLwfzdg68GaarCqQO8OHjLg7Ah05xTj7PsAYcoHeEg/9vYeBwGXBpRO8+Tjqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@swc/helpers": "^0.5.1"
-      }
-    },
-    "node_modules/@fluentui/react-accordion": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.11.0.tgz",
-      "integrity": "sha512-mEy73hbJM53tMj3MWqm3ajbBxj48uubnJjumVKI8Z/eXHS8L3GzUy5rf/gUH26xSR2Tl+edpFhYB8PFbJDIKKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-alert": {
-      "version": "9.0.0-beta.139",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.139.tgz",
-      "integrity": "sha512-R9r4dwwpWpgFmB8wVeWqipjUh/e6lyacnerX39HtVdgcG/PE+kpdHjKGiy8MAD+BGYCzrUxKNhXTQDlpXasJ1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-icons": "^2.0.239",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-aria": {
-      "version": "9.17.11",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.11.tgz",
-      "integrity": "sha512-K9nz+Wn5JliCpG6bIYYPXvKmpOql+w9uyzmYNYkYQ6QHgoCpph7XUFx1HCtsJm2PPNi8WO8g0ZV9jojdGKl1Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-avatar": {
-      "version": "9.11.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.1.tgz",
-      "integrity": "sha512-y1T67rVQQ/D4FAod8F4crXo9funaptscRIiW81LAsbN82fFVexMPQ9GmXooQQvn6ILvjJtf9IyvSJ195qDsyag==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-badge": "^9.5.2",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-popover": "^9.14.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-tooltip": "^9.10.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-badge": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.2.tgz",
-      "integrity": "sha512-+UPAK9dCD6Gx+LWr6vqKMIbYOPf7oXX+GXRtCJ5fekCTHD0VgIWuIMuEtxVrHpJQdb2VNaZadY8/dMomk2JaXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-breadcrumb": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.1.tgz",
-      "integrity": "sha512-XgUB1yv04GdcL/6kUo6kh+BaN4df1A/Ds/fL1QxNrm5E26Vmvvlc0LN0WV/qb5qhKx0NwhtIXgOZHjfzyt7iCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-link": "^9.8.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-button": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.9.1.tgz",
-      "integrity": "sha512-WNzpseiVbqEKKevTkAnyHNoK/8ktYPE6rvf31gGvSDnBBclqfrn4PSYG2ppi+Z7abmClnaNFxpp1OHuOoVQ8Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-calendar-compat": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-calendar-compat/-/react-calendar-compat-0.4.1.tgz",
-      "integrity": "sha512-CBCpZ5Jo0J/6MCi2l/USpiivY+W1avjeXsxlrfpdmqzyMYTWoaApwgYimosBTeSdw1zZTzmC1jJCAHXlMHB7iA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-card": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.6.1.tgz",
-      "integrity": "sha512-KBijjAxi0mBDSgnA1OCglqAVWc+Q0L7A2wCokszX/53oqfJPSvWxWFma7esz9b5MF/kdRrAR0vmy7MiosepNLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-text": "^9.6.16",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-carousel": {
-      "version": "9.9.7",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.7.tgz",
-      "integrity": "sha512-lummYk+tASL/rM/SXWruoqhUAyJjTiOMgiCz55ncE3q2pSZe/EbsV5WfRw5B3y7pHX8xLusN831TBgUthj/sUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-tooltip": "^9.10.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1",
-        "embla-carousel": "^8.5.1",
-        "embla-carousel-autoplay": "^8.5.1",
-        "embla-carousel-fade": "^8.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-checkbox": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.1.tgz",
-      "integrity": "sha512-Rsf3TmcNrzLuHan9lyUFUmMZnNyvS7DV8C4Vc9lZnZTFRBo94GRMGzu0BcWKFbr3cCDT/r5RmIyQYz0kc7Jd2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-color-picker": {
-      "version": "9.2.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.16.tgz",
-      "integrity": "sha512-+H8Ea8dwoSeUCTLRpUiGLrRsNvBnlHplnwJPU0isp8jdAfrIM/savZTLj6o4rqNFpNHQqAXxGwNuUV9YfHoJuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ctrl/tinycolor": "^3.3.4",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-combobox": {
-      "version": "9.17.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.1.tgz",
-      "integrity": "sha512-ezgt6tfOKd3wlG6IHvWl0TPNPpfHRtnEwC2kuqHYH/r1nMNp9edFi8Ya3+1eM7oxai19XW0swt69GPwRu51FVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-components": {
-      "version": "9.73.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.73.8.tgz",
-      "integrity": "sha512-JG4KQjEvRRfPlh4yt6Rv1/k87ydM2y49r5XPNCnuYHahA7kEM+dY8JdOI7n7FW8bdcvZ7qt4smDrQ2XcPfmxlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-accordion": "^9.11.0",
-        "@fluentui/react-alert": "9.0.0-beta.139",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-badge": "^9.5.2",
-        "@fluentui/react-breadcrumb": "^9.4.1",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-card": "^9.6.1",
-        "@fluentui/react-carousel": "^9.9.7",
-        "@fluentui/react-checkbox": "^9.6.1",
-        "@fluentui/react-color-picker": "^9.2.16",
-        "@fluentui/react-combobox": "^9.17.1",
-        "@fluentui/react-dialog": "^9.18.0",
-        "@fluentui/react-divider": "^9.7.1",
-        "@fluentui/react-drawer": "^9.12.0",
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-image": "^9.4.1",
-        "@fluentui/react-infobutton": "9.0.0-beta.115",
-        "@fluentui/react-infolabel": "^9.4.20",
-        "@fluentui/react-input": "^9.8.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-link": "^9.8.1",
-        "@fluentui/react-list": "^9.6.14",
-        "@fluentui/react-menu": "^9.24.1",
-        "@fluentui/react-message-bar": "^9.7.0",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-nav": "^9.3.24",
-        "@fluentui/react-overflow": "^9.7.2",
-        "@fluentui/react-persona": "^9.7.3",
-        "@fluentui/react-popover": "^9.14.2",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
-        "@fluentui/react-progress": "^9.5.1",
-        "@fluentui/react-provider": "^9.22.16",
-        "@fluentui/react-radio": "^9.6.2",
-        "@fluentui/react-rating": "^9.4.1",
-        "@fluentui/react-search": "^9.4.2",
-        "@fluentui/react-select": "^9.5.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-skeleton": "^9.7.2",
-        "@fluentui/react-slider": "^9.6.2",
-        "@fluentui/react-spinbutton": "^9.6.2",
-        "@fluentui/react-spinner": "^9.8.2",
-        "@fluentui/react-swatch-picker": "^9.5.2",
-        "@fluentui/react-switch": "^9.7.2",
-        "@fluentui/react-table": "^9.19.15",
-        "@fluentui/react-tabs": "^9.12.1",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-tag-picker": "^9.8.6",
-        "@fluentui/react-tags": "^9.8.1",
-        "@fluentui/react-teaching-popover": "^9.6.21",
-        "@fluentui/react-text": "^9.6.16",
-        "@fluentui/react-textarea": "^9.7.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-toast": "^9.7.17",
-        "@fluentui/react-toolbar": "^9.8.0",
-        "@fluentui/react-tooltip": "^9.10.1",
-        "@fluentui/react-tree": "^9.16.0",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@fluentui/react-virtualizer": "9.0.0-alpha.112",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-context-selector": {
-      "version": "9.2.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.16.tgz",
-      "integrity": "sha512-D+/X2liT+eZe0rzXbwddPH333ml2SXz71biR13aeyGJQr8+W+icMAIsYhpwk0CC3KtJ3f1/CLTm7vcIrvqsJ4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-utilities": "^9.26.3",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0",
-        "scheduler": ">=0.19.0"
-      }
-    },
-    "node_modules/@fluentui/react-datepicker-compat": {
-      "version": "0.6.31",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-datepicker-compat/-/react-datepicker-compat-0.6.31.tgz",
-      "integrity": "sha512-0ykcoK6y4sHHSknvwx3yduVr7nDcgl6dr9tRn+HF7fIetwZfOhlyn37jr9QN7ZledVotStDYUXegI5kqzMsZng==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-calendar-compat": "^0.4.1",
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-input": "^9.8.2",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-popover": "^9.14.2",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-dialog": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.18.0.tgz",
-      "integrity": "sha512-i+V2o0NJ1itjVADJFov5AR/JetpD2hCMiLye0vfi3/XsFMgEPZnGzILVxPCO/ovULTiCyThcL1UvY0d/PYrZfA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-divider": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.1.tgz",
-      "integrity": "sha512-ptymE6iADb/ugezulaMeoAfGxKSwOjHEHBh8N1ydOR3AoOxsSUPkvoPC0mReO/yV5Nas7pz5s5VuJTspmFz0hA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-drawer": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.12.0.tgz",
-      "integrity": "sha512-PUXeXUH6JqwpjqYphHesHl75UAFSvxQJQqrevMFHE78ZF0Cqn59Xpa+8hGwRSuoRcYa90jjfHzJOOjN0iNM2iA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-dialog": "^9.18.0",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-field": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.1.tgz",
-      "integrity": "sha512-u8J2d3AWb4yZXvy/mQd95y2lTon890RfybBTCbeBUzApGMI/77WqT5pRJ+zTM3lOMToPHVKylchNFusMpJaX9w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-icons": {
-      "version": "2.0.326",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.326.tgz",
-      "integrity": "sha512-iSN6YggrrQyZ46Jxk998Umm9jehWs6mrqCsrAvr7+uZWY6IwfYcoz94NCJ2SDiMO8Jompl4Y4Yu73SwljuUULQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@griffel/react": "^1.6.1",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-image": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.1.tgz",
-      "integrity": "sha512-yNd2Wq2xq952UUEVBkWeEmM7bTKdWx6BnsHPYRf0kdTADox2PquApYXsI1xw2pnAh3GSjARrGi9Eto0qxouLqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-infobutton": {
-      "version": "9.0.0-beta.115",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.115.tgz",
-      "integrity": "sha512-b+4B0ODzPEb4jNaW9HdT6VVt3CL5FgPL2yuKzALBsYVl3udJdFpyxHsZEPf3JrVTBL/rgF2fRI1iAioX6Fl7DA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-icons": "^2.0.237",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-popover": "^9.14.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-infolabel": {
-      "version": "9.4.20",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.20.tgz",
-      "integrity": "sha512-w4FOnNP+CtbVdKBEO6wXAcmOuPZWvmB/BJj+7J/8cLAQm7+4kQgitFHncU6rtFhPdGbikVoBf707/0R1mA4aIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-popover": "^9.14.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-input": {
-      "version": "9.8.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.2.tgz",
-      "integrity": "sha512-t9zmqZR4bqeRjpWuCGfI4yrtPoCXFiK2XO4BoV5nNwAesglgz4+Vtso4YXst9QYEAazHtKI73YFJf1mn55hCuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-jsx-runtime": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.2.tgz",
-      "integrity": "sha512-y3o0PBg2qzSdvgxDm7rH9BWq7E1h/eUWS+IhjQhd9dRpme6Py01+OLOglHojM5Tc9QjIp2Rjy2mFWBHXOR+8mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-utilities": "^9.26.3",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-label": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.1.tgz",
-      "integrity": "sha512-4O3cPX6dSJVBKlIEbznjJ08utEc98lKbZz/6MZTTQfFgYl0TxAhxEDsIIIyNjj0Xy9eJpqubJsaswucWXTG/qg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-link": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.1.tgz",
-      "integrity": "sha512-ZxrCeX4pMWHujdmYV8b0QW0ztLtu0rHHvRNx67Y3WqSijVyij8QtNNiZ/nab+UDNlz9t8QIXKdWQgYj1uKDpMg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-list": {
-      "version": "9.6.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.14.tgz",
-      "integrity": "sha512-B1mUQFvJOUlZysSduVnATNZggrGpgEWnW9ZSJAZ17LM0+9nWEQRi40jpUGI/d3PGKHt5O2df78s+1nEPAk0L6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-checkbox": "^9.6.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-menu": {
-      "version": "9.24.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.24.1.tgz",
-      "integrity": "sha512-NLB5EhzKFiwax3O5JTRTtsqdEFDGEXzEuP/suyxNAaaQsIuXygo//Rmdq6dSn7GybTpEOZHKxYDyyG7dj+a4YA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-message-bar": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.7.0.tgz",
-      "integrity": "sha512-ICFDxZ62r5OG97/FcfK1EfJPxGlyDNyFixLD/a3gOREvEcT/hyZgnlUM9Y30u92HjxChx2SwGWnv3iaQPsvToQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-link": "^9.8.1",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-motion": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.15.0.tgz",
-      "integrity": "sha512-ZNQHYzE6MRbLQFT08/mrcqQ9k7F5niktRP93X1v/kmwKfPjvdDofySfbhQXQs3zQw600690C9rfJTKUd3h+zlg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-motion-components-preview": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.4.tgz",
-      "integrity": "sha512-gAHPlyEYylZzUSGwc68VaB+vO8CTX6tgIA3d2+jFrpcwvXZjsdCpF1w1zK1+hTuiipmEaZLZyBz0e0CKH2+3XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-motion": "*",
-        "@fluentui/react-utilities": "*",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-nav": {
-      "version": "9.3.24",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.24.tgz",
-      "integrity": "sha512-OlB5k5Zev5VNjSRfJvJLO09Hjcv2UHAjLpSVa6gKHx+1NqqSJWZeDLSF7r+/nyZ4CWP5jWZYq7whEu3WvzdVZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-divider": "^9.7.1",
-        "@fluentui/react-drawer": "^9.12.0",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-tooltip": "^9.10.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-overflow": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.7.2.tgz",
-      "integrity": "sha512-5PA67LgnVmbbOzBN2H5gH3OvSVy1373VJfsHq2+6TLCfm+LXAkWBoFwvBuFI7HsMYae9A0FVlgX7gTsKVfMddw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/priority-overflow": "^9.3.0",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-persona": {
-      "version": "9.7.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.3.tgz",
-      "integrity": "sha512-OY3xpSD6l4NDdeKihriC+H0q6P1CA2xyZ+pe/WwfKPnatxs2BALoRFtDQduMO7AK/j0w7UAxnaZrvEeftLen2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-badge": "^9.5.2",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-popover": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.2.tgz",
-      "integrity": "sha512-EDvzLkT98/vcCSGrcZWUACGsvLjrHin0Xf9eowMQKiiHFWbu8HNRmr7W2XB9Eja1W5HSIK6+mV8ro9zrLibG4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-portal": {
-      "version": "9.8.12",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.12.tgz",
-      "integrity": "sha512-+WH0wH/5lsodGP6Mam1alHXpkMCYA5uMcnF98RVOs7/GR69KiFcza1mCnvPJUaJ55AfwLuz/xLxuWdWgQnUdMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-positioning": {
-      "version": "9.22.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.1.tgz",
-      "integrity": "sha512-/r1BHQKr/WCjEM8UGloiq7bWWBSYB/Uqt7D1sAF9EHd968VH07cAN3RMVKmWWjeJO31rstOZHdgcz0WHhFF+2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/devtools": "^0.2.3",
-        "@floating-ui/dom": "^1.6.12",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-progress": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.1.tgz",
-      "integrity": "sha512-EXJ/Bp67d5+bXPNpPabxdtXUgCMTtvYrBoKtIS6wE5KeUzaek/rgQ3v5wnGfbuLnJ4J/kj+n7XQEc9fhoFPy9w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-provider": {
-      "version": "9.22.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.16.tgz",
-      "integrity": "sha512-S77n5ASUWE/V1I6lX09CrHm4TAKSGENhIrKz9qMKDv2Vrq44/j3eGBLz12k8IW4TJVu9nwGwst9kBpCT+3WHpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/core": "^1.16.0",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-radio": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.2.tgz",
-      "integrity": "sha512-Sp2us4eWRopUKOMCQw5/iks7euPKY6FeesBCCUIVGBg5VKZf2/CfEtbCa9hMjn4D4PCHGivnUTf23t238mvvnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-rating": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.1.tgz",
-      "integrity": "sha512-DfWipzrT44j+yaShtfHz96/vHEa5ut5IR1kobrO0bSqAcpetOn327gFeY+sG/W6xzork/STcy/T836yK8A2+DQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-search": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.2.tgz",
-      "integrity": "sha512-PIb50euHoMsKWLqFymf8wo/+z1jrx1MB7uNuhjNT5DvwTP4VYAy5EtRCSwVRyxWNSaWSL6iy6dDy517EQE96mA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-input": "^9.8.2",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-select": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.1.tgz",
-      "integrity": "sha512-8GocQKiUHEUlAks6zA0HbGGSF2lpjuSZuxPzIBqTyuWof8vFiK6eFAcSXb0hTYIVH3RsTihhfc6G3NRnHoBrzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-shared-contexts": {
-      "version": "9.26.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
-      "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-theme": "^9.2.1",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-skeleton": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.2.tgz",
-      "integrity": "sha512-PrUgdSGDAZw9FIP5NyvPoPfHDe2N9VxMyBfyTwWfZVg03dzRfnE3vEqr7N5xyfv4JsRs6u1xSqVn/0jdS0IEMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-slider": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.2.tgz",
-      "integrity": "sha512-lVavtTg8eqovfRokeYDk4popwCi8nuicacJ/HZdF3ni5e3y/2WT/bVP0eErS/GvC7+90ACQQ8uxdr4sjjY/HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-spinbutton": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.2.tgz",
-      "integrity": "sha512-P4vvJH7P5yHPFAv6aSo3dZxtErN62DiRJN+nEKS+/XBoRGsOGQdqyyx5Q/PQKOmyQrtwuZdXNHUjcyv8b50T2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-spinner": {
-      "version": "9.8.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.2.tgz",
-      "integrity": "sha512-0LxykLJGUD/I3XEeIXAWznwdg9XRe0piaByR0nLFOOV3UPwkVc2w5UdPhy2Y0NZDvtPHbNaMCuQAq82+bxg/0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-swatch-picker": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.2.tgz",
-      "integrity": "sha512-DK6UU9OJY9XaGBPU2ROx+B5/7XdwVtHBdVthOAptyKSsYGOdQt5AQqg3ZOXH6r5WYbMRQDuP2OZ2iKtwidFCVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-switch": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.2.tgz",
-      "integrity": "sha512-j3e5se+3d+befV9MytkxxvJ9nHZOeZ7thKDTF4YVSYf6kcNx9eOlLvPgDjhGO08gzngO4B7aaprhDN7DJc3W1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-label": "^9.4.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-table": {
-      "version": "9.19.15",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.15.tgz",
-      "integrity": "sha512-OdQ2Nwx2nAlPMlJeyAFrKa3Zy5Ya/H87OU8MvtFJhabM/FkHiZoli/DO1mavVI+jqavOlJuQWmJ55D6jjuGa7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-checkbox": "^9.6.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-radio": "^9.6.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-tabs": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.1.tgz",
-      "integrity": "sha512-WvzOtpC6C/7Mo5X+xmE+3stpCbx2iH9BqrEN5KuGrsHJ78DjMDeabYeL90vlrHBdP4VlTpwdORBui/jtWkxnmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-tabster": {
-      "version": "9.26.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.14.tgz",
-      "integrity": "sha512-WibgoF67hl6BXfmsY6RSIWSHadeMP/6EDG9gAacfHlwKvK0+FiHp5ernwuXTPAmu2kiHicn2qUZ8EteCFiFryg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1",
-        "keyborg": "^2.6.0",
-        "tabster": "^8.5.5"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-tag-picker": {
-      "version": "9.8.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.8.6.tgz",
-      "integrity": "sha512-sOZ+wBA3hgGhKrOP7wbjB2yRvAxjcRXtcj1jDTrtSkaDPXb3K0nGmjiqp2mve995ps3wvCGnNKK4EurX842ZbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-combobox": "^9.17.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-tags": "^9.8.1",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-tags": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.8.1.tgz",
-      "integrity": "sha512-6ZTW78fu5eWByKHIM3i+raDrX3hwfZ67ONfZ8wEUXfZHowskxqpMHI8Gw7IAMWkC1scgLqEnht8TnHvZgjo7Ug==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-teaching-popover": {
-      "version": "9.6.21",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.21.tgz",
-      "integrity": "sha512-V86zLB1B8xu3U/02FvvMdsJP+ZC9l3vT9bQ2Gr7hZHxJ4/0NLpVcrYSBFHpON9e/WK3p+A5b5V96p86b5Pavlg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-popover": "^9.14.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-text": {
-      "version": "9.6.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.16.tgz",
-      "integrity": "sha512-ZzCSJWQ6LrVuPqA6sqNEZaXbLvhi2NxBOtlMudWlqYzidLQp038d7mMGSzNnhyeblg+gj+bOVE2eOgWFuVHGYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-textarea": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.2.tgz",
-      "integrity": "sha512-awlkZoW81WaOqSoXTT9rZs3mTAzCCHnC9eAm6J8ZxI5+ASX07BTolBfZ82it5wxOHI5GMDfbFOl+xIy8uAMdzA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-theme": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
-      "integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/tokens": "1.0.0-alpha.23",
-        "@swc/helpers": "^0.5.1"
-      }
-    },
-    "node_modules/@fluentui/react-timepicker-compat": {
-      "version": "0.4.34",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-timepicker-compat/-/react-timepicker-compat-0.4.34.tgz",
-      "integrity": "sha512-G0As6kh5uzDHv68/lJSVfBiAN8Qn6KmWL6wIsvVKt/aezVbsr1X9SaYL/lOG3+qa1m+ZiLqmDUVuBPsC9PK29w==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-combobox": "^9.17.1",
-        "@fluentui/react-field": "^9.5.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0 <20.0.0",
-        "@types/react-dom": ">=16.8.0 <20.0.0",
-        "react": ">=16.8.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-toast": {
-      "version": "9.7.17",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.7.17.tgz",
-      "integrity": "sha512-DWA5EARWSo1k19iWAulLpKrcUHT+Dq/Bw9zfdpoQEWWybrAZwyN7WiYFkBjKCQRxSp10OjLASSQK91CXfb1wJA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-toolbar": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.8.0.tgz",
-      "integrity": "sha512-EIe+QWOaFR1pZzENefsFTmjxGa2yJb4A/by3kGuGqSjx7isqPUllPq0/kFQzfoUYgPDJbJtQ+KyuRDekTL0QpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-divider": "^9.7.1",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-radio": "^9.6.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-tooltip": {
-      "version": "9.10.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.1.tgz",
-      "integrity": "sha512-IPHBFjqGhaaMDhLt5NSNOE9LEpDOpT7qgEqNz+Mlflo0A4qI2LW/EnkNop7IRmX/bC88A+wUtEONTjjR87dNBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-portal": "^9.8.12",
-        "@fluentui/react-positioning": "^9.22.1",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-tree": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.16.0.tgz",
-      "integrity": "sha512-c+Q4AVaYk9U69aGDgmJVNne+CtWKS75YIfGoxs6+9+wE2Wqz4T0E+gE1ng7ARCQQgI7E2NEJlot6DuI6nYYrRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.11",
-        "@fluentui/react-avatar": "^9.11.1",
-        "@fluentui/react-button": "^9.9.1",
-        "@fluentui/react-checkbox": "^9.6.1",
-        "@fluentui/react-context-selector": "^9.2.16",
-        "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-motion": "^9.15.0",
-        "@fluentui/react-motion-components-preview": "^0.15.4",
-        "@fluentui/react-radio": "^9.6.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-tabster": "^9.26.14",
-        "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-utilities": {
-      "version": "9.26.3",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.3.tgz",
-      "integrity": "sha512-bXB3jMm/RroT8c5eGZkijkPbLd4MqMI6biBHjavo0e7OkZHv9IPfH2nDkGhSn5Sh8e6kRcX0IjYhbM10WUK2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/react-virtualizer": {
-      "version": "9.0.0-alpha.112",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.112.tgz",
-      "integrity": "sha512-dao/mQssaPFxCXMx7K+G/DrRoZg28kXcE1NGbJ1RPtbkVCzJgwrEEeDhM5/wyOXO/Z5EZ31FIerDDVOyr6FAaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.4.2",
-        "@fluentui/react-shared-contexts": "^9.26.2",
-        "@fluentui/react-utilities": "^9.26.3",
-        "@griffel/react": "^1.5.32",
-        "@swc/helpers": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0 <20.0.0",
-        "@types/react-dom": ">=16.9.0 <20.0.0",
-        "react": ">=16.14.0 <20.0.0",
-        "react-dom": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@fluentui/tokens": {
-      "version": "1.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
-      "integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@swc/helpers": "^0.5.1"
-      }
-    },
-    "node_modules/@griffel/core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.0.tgz",
-      "integrity": "sha512-QqMoewiNTT0DmLM7OY607c7yhg18SuKfzovTO3hPXGQvtdu/StnjvuBAs+1B1kYSVGReAo6s/dJVeLnPuHjE7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.0",
-        "@griffel/style-types": "^1.4.0",
-        "csstype": "^3.1.3",
-        "rtl-css-js": "^1.16.1",
-        "stylis": "^4.4.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@griffel/react": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.7.2.tgz",
-      "integrity": "sha512-/+N+81e9ibNsh2wNlhGf2PcimEFrx8VbtWiLCmI6lsrTV5eBcQrIIDVQq737KPIJFtD4v6Txu9n0PXbN3hedNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@griffel/core": "^1.21.0",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.14.0 <20.0.0"
-      }
-    },
-    "node_modules/@griffel/style-types": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.0.tgz",
-      "integrity": "sha512-vNDfOGV7RN/XkA7vxgf7Z5HgW8eiBm5cHT9wQPhsKB4pxWom5u6eQ9CkYE5mCCTSPl9H6Nd1NBai04d4P6BD7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.3"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@monaco-editor/loader": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
-      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
-      "license": "MIT",
-      "dependencies": {
-        "state-local": "^1.0.6"
-      }
-    },
-    "node_modules/@monaco-editor/react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
-      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@monaco-editor/loader": "^1.5.0"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@pptb/types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@pptb/types/-/types-1.2.1.tgz",
-      "integrity": "sha512-U8/Tij6CB09T+g/lE3gubdNnw7wmHz4LKoaWCMiXsv6BTNliXD99Wt6XW1K7WWdUwhIknKK9Jor3YhzoboVhHA==",
-      "dev": true,
-      "license": "GPL-3.0",
-      "bin": {
-        "pptb-validate": "bin/pptb-validate.js"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
-      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
-      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
-      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
-      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
-      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
-      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
-      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
-      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
-      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
-      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
-      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
-      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
-      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
-      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
-      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
-      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
-      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
-      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
-      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
-      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
-      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
-      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
-      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
-      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
-      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@vitejs/plugin-react": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
-      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.29.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-rc.3",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.18.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.351",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.351.tgz",
-      "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/embla-carousel": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
-      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
-    },
-    "node_modules/embla-carousel-autoplay": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
-      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "embla-carousel": "8.6.0"
-      }
-    },
-    "node_modules/embla-carousel-fade": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
-      "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "embla-carousel": "8.6.0"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/keyborg": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.14.1.tgz",
-      "integrity": "sha512-/WmmVBa6Me3hIKAOIyIq1sql+6oydQZzGMBDLNfOcJ8710byMsq3KSLS8GQhBJHOMtvnXnUBrDAIbABcZVipcg==",
-      "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "license": "MIT"
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
-      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "3.1.7",
-        "marked": "14.0.0"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/react-refresh": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-window": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
-      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
-      },
-      "engines": {
-        "node": ">8.0.0"
-      },
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
-      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.3",
-        "@rollup/rollup-android-arm64": "4.60.3",
-        "@rollup/rollup-darwin-arm64": "4.60.3",
-        "@rollup/rollup-darwin-x64": "4.60.3",
-        "@rollup/rollup-freebsd-arm64": "4.60.3",
-        "@rollup/rollup-freebsd-x64": "4.60.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
-        "@rollup/rollup-linux-arm64-musl": "4.60.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
-        "@rollup/rollup-linux-loong64-musl": "4.60.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
-        "@rollup/rollup-linux-x64-gnu": "4.60.3",
-        "@rollup/rollup-linux-x64-musl": "4.60.3",
-        "@rollup/rollup-openbsd-x64": "4.60.3",
-        "@rollup/rollup-openharmony-arm64": "4.60.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
-        "@rollup/rollup-win32-x64-gnu": "4.60.3",
-        "@rollup/rollup-win32-x64-msvc": "4.60.3",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/rtl-css-js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
-      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/state-local": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
-      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
-      "license": "MIT"
-    },
-    "node_modules/stylis": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
-      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
-      "license": "MIT"
-    },
-    "node_modules/tabster": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.8.0.tgz",
-      "integrity": "sha512-eGFXgtvKOQP5BywDI9Ngs+Atm6TRj45epAAqWKyVoi+HmOmdamEB//1H/FttLdNly/+Cz+GJ4RN8TnXTw0KwfA==",
-      "license": "MIT",
-      "dependencies": {
-        "keyborg": "^2.14.0",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
-    }
-  }
+	"name": "@mohsinonxrm/pptb-dataverse-request-studio",
+	"version": "1.1.2",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@mohsinonxrm/pptb-dataverse-request-studio",
+			"version": "1.1.2",
+			"license": "AGPL-3.0-only",
+			"dependencies": {
+				"@dnd-kit/core": "^6.3.1",
+				"@dnd-kit/sortable": "^10.0.0",
+				"@dnd-kit/utilities": "^3.2.2",
+				"@fluentui-contrib/react-data-grid-react-window": "^1.4.2",
+				"@fluentui/react-components": "^9.73.8",
+				"@fluentui/react-datepicker-compat": "^0.6.31",
+				"@fluentui/react-icons": "^2.0.326",
+				"@fluentui/react-timepicker-compat": "^0.4.34",
+				"@monaco-editor/react": "^4.7.0",
+				"monaco-editor": "^0.54.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"devDependencies": {
+				"@pptb/types": "^1.2.1",
+				"@types/react": "^18.3.28",
+				"@types/react-dom": "^18.3.7",
+				"@vitejs/plugin-react": "^5.2.0",
+				"typescript": "~5.9.3",
+				"vite": "^7.3.3"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/compat-data": {
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+			"integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/core": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.29.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-validator-option": "^7.27.1",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/traverse": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-plugin-utils": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-option": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helpers": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx-self": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+			"integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx-source": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+			"integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@ctrl/tinycolor": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+			"integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@dnd-kit/accessibility": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+			"integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/core": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+			"integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/accessibility": "^3.1.1",
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/sortable": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+			"integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/utilities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+			"integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@emotion/hash": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+			"license": "MIT"
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.11"
+			}
+		},
+		"node_modules/@floating-ui/devtools": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.3.tgz",
+			"integrity": "sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@floating-ui/dom": "^1.0.0"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.7.5",
+				"@floating-ui/utils": "^0.2.11"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+			"license": "MIT"
+		},
+		"node_modules/@fluentui-contrib/react-data-grid-react-window": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@fluentui-contrib/react-data-grid-react-window/-/react-data-grid-react-window-1.4.2.tgz",
+			"integrity": "sha512-pYPa6pgKlDpfUybMExfk8UifAJV+p6eAmjpS4l2iLBDLOaY41YHtKO8IEaNe3ogISJuEWmJFCPUa5LIzlXQxhw==",
+			"license": "MIT",
+			"dependencies": {
+				"@swc/helpers": "~0.5.11",
+				"react-window": "^1.8.5"
+			},
+			"peerDependencies": {
+				"@fluentui/react-components": ">=9.70.0 <10.0.0",
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.8.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/keyboard-keys": {
+			"version": "9.0.8",
+			"resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
+			"integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+			"license": "MIT",
+			"dependencies": {
+				"@swc/helpers": "^0.5.1"
+			}
+		},
+		"node_modules/@fluentui/priority-overflow": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.3.0.tgz",
+			"integrity": "sha512-yaBC0R4e+4ZlCWDulB5S+xBrlnLwfzdg68GaarCqQO8OHjLg7Ah05xTj7PsAYcoHeEg/9vYeBwGXBpRO8+Tjqw==",
+			"license": "MIT",
+			"dependencies": {
+				"@swc/helpers": "^0.5.1"
+			}
+		},
+		"node_modules/@fluentui/react-accordion": {
+			"version": "9.11.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.11.0.tgz",
+			"integrity": "sha512-mEy73hbJM53tMj3MWqm3ajbBxj48uubnJjumVKI8Z/eXHS8L3GzUy5rf/gUH26xSR2Tl+edpFhYB8PFbJDIKKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-motion-components-preview": "^0.15.4",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-alert": {
+			"version": "9.0.0-beta.139",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.139.tgz",
+			"integrity": "sha512-R9r4dwwpWpgFmB8wVeWqipjUh/e6lyacnerX39HtVdgcG/PE+kpdHjKGiy8MAD+BGYCzrUxKNhXTQDlpXasJ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-avatar": "^9.11.1",
+				"@fluentui/react-button": "^9.9.1",
+				"@fluentui/react-icons": "^2.0.239",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-aria": {
+			"version": "9.17.11",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.11.tgz",
+			"integrity": "sha512-K9nz+Wn5JliCpG6bIYYPXvKmpOql+w9uyzmYNYkYQ6QHgoCpph7XUFx1HCtsJm2PPNi8WO8g0ZV9jojdGKl1Tg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-avatar": {
+			"version": "9.11.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.1.tgz",
+			"integrity": "sha512-y1T67rVQQ/D4FAod8F4crXo9funaptscRIiW81LAsbN82fFVexMPQ9GmXooQQvn6ILvjJtf9IyvSJ195qDsyag==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-badge": "^9.5.2",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-popover": "^9.14.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-tooltip": "^9.10.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-badge": {
+			"version": "9.5.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.2.tgz",
+			"integrity": "sha512-+UPAK9dCD6Gx+LWr6vqKMIbYOPf7oXX+GXRtCJ5fekCTHD0VgIWuIMuEtxVrHpJQdb2VNaZadY8/dMomk2JaXw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-breadcrumb": {
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.1.tgz",
+			"integrity": "sha512-XgUB1yv04GdcL/6kUo6kh+BaN4df1A/Ds/fL1QxNrm5E26Vmvvlc0LN0WV/qb5qhKx0NwhtIXgOZHjfzyt7iCA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-button": "^9.9.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-link": "^9.8.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-button": {
+			"version": "9.9.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.9.1.tgz",
+			"integrity": "sha512-WNzpseiVbqEKKevTkAnyHNoK/8ktYPE6rvf31gGvSDnBBclqfrn4PSYG2ppi+Z7abmClnaNFxpp1OHuOoVQ8Bg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-calendar-compat": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-calendar-compat/-/react-calendar-compat-0.4.1.tgz",
+			"integrity": "sha512-CBCpZ5Jo0J/6MCi2l/USpiivY+W1avjeXsxlrfpdmqzyMYTWoaApwgYimosBTeSdw1zZTzmC1jJCAHXlMHB7iA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.8.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-card": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.6.1.tgz",
+			"integrity": "sha512-KBijjAxi0mBDSgnA1OCglqAVWc+Q0L7A2wCokszX/53oqfJPSvWxWFma7esz9b5MF/kdRrAR0vmy7MiosepNLQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-text": "^9.6.16",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-carousel": {
+			"version": "9.9.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.7.tgz",
+			"integrity": "sha512-lummYk+tASL/rM/SXWruoqhUAyJjTiOMgiCz55ncE3q2pSZe/EbsV5WfRw5B3y7pHX8xLusN831TBgUthj/sUw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-button": "^9.9.1",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-tooltip": "^9.10.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1",
+				"embla-carousel": "^8.5.1",
+				"embla-carousel-autoplay": "^8.5.1",
+				"embla-carousel-fade": "^8.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-checkbox": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.1.tgz",
+			"integrity": "sha512-Rsf3TmcNrzLuHan9lyUFUmMZnNyvS7DV8C4Vc9lZnZTFRBo94GRMGzu0BcWKFbr3cCDT/r5RmIyQYz0kc7Jd2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-label": "^9.4.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-color-picker": {
+			"version": "9.2.16",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.16.tgz",
+			"integrity": "sha512-+H8Ea8dwoSeUCTLRpUiGLrRsNvBnlHplnwJPU0isp8jdAfrIM/savZTLj6o4rqNFpNHQqAXxGwNuUV9YfHoJuQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ctrl/tinycolor": "^3.3.4",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-combobox": {
+			"version": "9.17.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.1.tgz",
+			"integrity": "sha512-ezgt6tfOKd3wlG6IHvWl0TPNPpfHRtnEwC2kuqHYH/r1nMNp9edFi8Ya3+1eM7oxai19XW0swt69GPwRu51FVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-positioning": "^9.22.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-components": {
+			"version": "9.73.8",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.73.8.tgz",
+			"integrity": "sha512-JG4KQjEvRRfPlh4yt6Rv1/k87ydM2y49r5XPNCnuYHahA7kEM+dY8JdOI7n7FW8bdcvZ7qt4smDrQ2XcPfmxlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-accordion": "^9.11.0",
+				"@fluentui/react-alert": "9.0.0-beta.139",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-avatar": "^9.11.1",
+				"@fluentui/react-badge": "^9.5.2",
+				"@fluentui/react-breadcrumb": "^9.4.1",
+				"@fluentui/react-button": "^9.9.1",
+				"@fluentui/react-card": "^9.6.1",
+				"@fluentui/react-carousel": "^9.9.7",
+				"@fluentui/react-checkbox": "^9.6.1",
+				"@fluentui/react-color-picker": "^9.2.16",
+				"@fluentui/react-combobox": "^9.17.1",
+				"@fluentui/react-dialog": "^9.18.0",
+				"@fluentui/react-divider": "^9.7.1",
+				"@fluentui/react-drawer": "^9.12.0",
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-image": "^9.4.1",
+				"@fluentui/react-infobutton": "9.0.0-beta.115",
+				"@fluentui/react-infolabel": "^9.4.20",
+				"@fluentui/react-input": "^9.8.2",
+				"@fluentui/react-label": "^9.4.1",
+				"@fluentui/react-link": "^9.8.1",
+				"@fluentui/react-list": "^9.6.14",
+				"@fluentui/react-menu": "^9.24.1",
+				"@fluentui/react-message-bar": "^9.7.0",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-nav": "^9.3.24",
+				"@fluentui/react-overflow": "^9.7.2",
+				"@fluentui/react-persona": "^9.7.3",
+				"@fluentui/react-popover": "^9.14.2",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-positioning": "^9.22.1",
+				"@fluentui/react-progress": "^9.5.1",
+				"@fluentui/react-provider": "^9.22.16",
+				"@fluentui/react-radio": "^9.6.2",
+				"@fluentui/react-rating": "^9.4.1",
+				"@fluentui/react-search": "^9.4.2",
+				"@fluentui/react-select": "^9.5.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-skeleton": "^9.7.2",
+				"@fluentui/react-slider": "^9.6.2",
+				"@fluentui/react-spinbutton": "^9.6.2",
+				"@fluentui/react-spinner": "^9.8.2",
+				"@fluentui/react-swatch-picker": "^9.5.2",
+				"@fluentui/react-switch": "^9.7.2",
+				"@fluentui/react-table": "^9.19.15",
+				"@fluentui/react-tabs": "^9.12.1",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-tag-picker": "^9.8.6",
+				"@fluentui/react-tags": "^9.8.1",
+				"@fluentui/react-teaching-popover": "^9.6.21",
+				"@fluentui/react-text": "^9.6.16",
+				"@fluentui/react-textarea": "^9.7.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-toast": "^9.7.17",
+				"@fluentui/react-toolbar": "^9.8.0",
+				"@fluentui/react-tooltip": "^9.10.1",
+				"@fluentui/react-tree": "^9.16.0",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@fluentui/react-virtualizer": "9.0.0-alpha.112",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-context-selector": {
+			"version": "9.2.16",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.16.tgz",
+			"integrity": "sha512-D+/X2liT+eZe0rzXbwddPH333ml2SXz71biR13aeyGJQr8+W+icMAIsYhpwk0CC3KtJ3f1/CLTm7vcIrvqsJ4g==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-utilities": "^9.26.3",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0",
+				"scheduler": ">=0.19.0"
+			}
+		},
+		"node_modules/@fluentui/react-datepicker-compat": {
+			"version": "0.6.31",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-datepicker-compat/-/react-datepicker-compat-0.6.31.tgz",
+			"integrity": "sha512-0ykcoK6y4sHHSknvwx3yduVr7nDcgl6dr9tRn+HF7fIetwZfOhlyn37jr9QN7ZledVotStDYUXegI5kqzMsZng==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-calendar-compat": "^0.4.1",
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-input": "^9.8.2",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-popover": "^9.14.2",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-positioning": "^9.22.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.8.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-dialog": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.18.0.tgz",
+			"integrity": "sha512-i+V2o0NJ1itjVADJFov5AR/JetpD2hCMiLye0vfi3/XsFMgEPZnGzILVxPCO/ovULTiCyThcL1UvY0d/PYrZfA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-motion-components-preview": "^0.15.4",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-divider": {
+			"version": "9.7.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.1.tgz",
+			"integrity": "sha512-ptymE6iADb/ugezulaMeoAfGxKSwOjHEHBh8N1ydOR3AoOxsSUPkvoPC0mReO/yV5Nas7pz5s5VuJTspmFz0hA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-drawer": {
+			"version": "9.12.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.12.0.tgz",
+			"integrity": "sha512-PUXeXUH6JqwpjqYphHesHl75UAFSvxQJQqrevMFHE78ZF0Cqn59Xpa+8hGwRSuoRcYa90jjfHzJOOjN0iNM2iA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-dialog": "^9.18.0",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-motion-components-preview": "^0.15.4",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-field": {
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.1.tgz",
+			"integrity": "sha512-u8J2d3AWb4yZXvy/mQd95y2lTon890RfybBTCbeBUzApGMI/77WqT5pRJ+zTM3lOMToPHVKylchNFusMpJaX9w==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-label": "^9.4.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-icons": {
+			"version": "2.0.326",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.326.tgz",
+			"integrity": "sha512-iSN6YggrrQyZ46Jxk998Umm9jehWs6mrqCsrAvr7+uZWY6IwfYcoz94NCJ2SDiMO8Jompl4Y4Yu73SwljuUULQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@griffel/react": "^1.6.1",
+				"tslib": "^2.1.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-image": {
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.1.tgz",
+			"integrity": "sha512-yNd2Wq2xq952UUEVBkWeEmM7bTKdWx6BnsHPYRf0kdTADox2PquApYXsI1xw2pnAh3GSjARrGi9Eto0qxouLqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-infobutton": {
+			"version": "9.0.0-beta.115",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.115.tgz",
+			"integrity": "sha512-b+4B0ODzPEb4jNaW9HdT6VVt3CL5FgPL2yuKzALBsYVl3udJdFpyxHsZEPf3JrVTBL/rgF2fRI1iAioX6Fl7DA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-icons": "^2.0.237",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-label": "^9.4.1",
+				"@fluentui/react-popover": "^9.14.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-infolabel": {
+			"version": "9.4.20",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.20.tgz",
+			"integrity": "sha512-w4FOnNP+CtbVdKBEO6wXAcmOuPZWvmB/BJj+7J/8cLAQm7+4kQgitFHncU6rtFhPdGbikVoBf707/0R1mA4aIg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-label": "^9.4.1",
+				"@fluentui/react-popover": "^9.14.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-input": {
+			"version": "9.8.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.2.tgz",
+			"integrity": "sha512-t9zmqZR4bqeRjpWuCGfI4yrtPoCXFiK2XO4BoV5nNwAesglgz4+Vtso4YXst9QYEAazHtKI73YFJf1mn55hCuA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-jsx-runtime": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.2.tgz",
+			"integrity": "sha512-y3o0PBg2qzSdvgxDm7rH9BWq7E1h/eUWS+IhjQhd9dRpme6Py01+OLOglHojM5Tc9QjIp2Rjy2mFWBHXOR+8mw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-utilities": "^9.26.3",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-label": {
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.1.tgz",
+			"integrity": "sha512-4O3cPX6dSJVBKlIEbznjJ08utEc98lKbZz/6MZTTQfFgYl0TxAhxEDsIIIyNjj0Xy9eJpqubJsaswucWXTG/qg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-link": {
+			"version": "9.8.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.1.tgz",
+			"integrity": "sha512-ZxrCeX4pMWHujdmYV8b0QW0ztLtu0rHHvRNx67Y3WqSijVyij8QtNNiZ/nab+UDNlz9t8QIXKdWQgYj1uKDpMg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-list": {
+			"version": "9.6.14",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.14.tgz",
+			"integrity": "sha512-B1mUQFvJOUlZysSduVnATNZggrGpgEWnW9ZSJAZ17LM0+9nWEQRi40jpUGI/d3PGKHt5O2df78s+1nEPAk0L6A==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-checkbox": "^9.6.1",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-menu": {
+			"version": "9.24.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.24.1.tgz",
+			"integrity": "sha512-NLB5EhzKFiwax3O5JTRTtsqdEFDGEXzEuP/suyxNAaaQsIuXygo//Rmdq6dSn7GybTpEOZHKxYDyyG7dj+a4YA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-motion-components-preview": "^0.15.4",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-positioning": "^9.22.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-message-bar": {
+			"version": "9.7.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.7.0.tgz",
+			"integrity": "sha512-ICFDxZ62r5OG97/FcfK1EfJPxGlyDNyFixLD/a3gOREvEcT/hyZgnlUM9Y30u92HjxChx2SwGWnv3iaQPsvToQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-button": "^9.9.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-link": "^9.8.1",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-motion-components-preview": "^0.15.4",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-motion": {
+			"version": "9.15.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.15.0.tgz",
+			"integrity": "sha512-ZNQHYzE6MRbLQFT08/mrcqQ9k7F5niktRP93X1v/kmwKfPjvdDofySfbhQXQs3zQw600690C9rfJTKUd3h+zlg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-motion-components-preview": {
+			"version": "0.15.4",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.4.tgz",
+			"integrity": "sha512-gAHPlyEYylZzUSGwc68VaB+vO8CTX6tgIA3d2+jFrpcwvXZjsdCpF1w1zK1+hTuiipmEaZLZyBz0e0CKH2+3XQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-motion": "*",
+				"@fluentui/react-utilities": "*",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-nav": {
+			"version": "9.3.24",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.24.tgz",
+			"integrity": "sha512-OlB5k5Zev5VNjSRfJvJLO09Hjcv2UHAjLpSVa6gKHx+1NqqSJWZeDLSF7r+/nyZ4CWP5jWZYq7whEu3WvzdVZw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-button": "^9.9.1",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-divider": "^9.7.1",
+				"@fluentui/react-drawer": "^9.12.0",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-motion-components-preview": "^0.15.4",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-tooltip": "^9.10.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-overflow": {
+			"version": "9.7.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.7.2.tgz",
+			"integrity": "sha512-5PA67LgnVmbbOzBN2H5gH3OvSVy1373VJfsHq2+6TLCfm+LXAkWBoFwvBuFI7HsMYae9A0FVlgX7gTsKVfMddw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/priority-overflow": "^9.3.0",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-persona": {
+			"version": "9.7.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.3.tgz",
+			"integrity": "sha512-OY3xpSD6l4NDdeKihriC+H0q6P1CA2xyZ+pe/WwfKPnatxs2BALoRFtDQduMO7AK/j0w7UAxnaZrvEeftLen2g==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-avatar": "^9.11.1",
+				"@fluentui/react-badge": "^9.5.2",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-popover": {
+			"version": "9.14.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.2.tgz",
+			"integrity": "sha512-EDvzLkT98/vcCSGrcZWUACGsvLjrHin0Xf9eowMQKiiHFWbu8HNRmr7W2XB9Eja1W5HSIK6+mV8ro9zrLibG4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-motion-components-preview": "^0.15.4",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-positioning": "^9.22.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-portal": {
+			"version": "9.8.12",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.12.tgz",
+			"integrity": "sha512-+WH0wH/5lsodGP6Mam1alHXpkMCYA5uMcnF98RVOs7/GR69KiFcza1mCnvPJUaJ55AfwLuz/xLxuWdWgQnUdMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-positioning": {
+			"version": "9.22.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.1.tgz",
+			"integrity": "sha512-/r1BHQKr/WCjEM8UGloiq7bWWBSYB/Uqt7D1sAF9EHd968VH07cAN3RMVKmWWjeJO31rstOZHdgcz0WHhFF+2Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/devtools": "^0.2.3",
+				"@floating-ui/dom": "^1.6.12",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-progress": {
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.1.tgz",
+			"integrity": "sha512-EXJ/Bp67d5+bXPNpPabxdtXUgCMTtvYrBoKtIS6wE5KeUzaek/rgQ3v5wnGfbuLnJ4J/kj+n7XQEc9fhoFPy9w==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-provider": {
+			"version": "9.22.16",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.16.tgz",
+			"integrity": "sha512-S77n5ASUWE/V1I6lX09CrHm4TAKSGENhIrKz9qMKDv2Vrq44/j3eGBLz12k8IW4TJVu9nwGwst9kBpCT+3WHpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/core": "^1.16.0",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-radio": {
+			"version": "9.6.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.2.tgz",
+			"integrity": "sha512-Sp2us4eWRopUKOMCQw5/iks7euPKY6FeesBCCUIVGBg5VKZf2/CfEtbCa9hMjn4D4PCHGivnUTf23t238mvvnw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-label": "^9.4.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-rating": {
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.1.tgz",
+			"integrity": "sha512-DfWipzrT44j+yaShtfHz96/vHEa5ut5IR1kobrO0bSqAcpetOn327gFeY+sG/W6xzork/STcy/T836yK8A2+DQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-search": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.2.tgz",
+			"integrity": "sha512-PIb50euHoMsKWLqFymf8wo/+z1jrx1MB7uNuhjNT5DvwTP4VYAy5EtRCSwVRyxWNSaWSL6iy6dDy517EQE96mA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-input": "^9.8.2",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-select": {
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.1.tgz",
+			"integrity": "sha512-8GocQKiUHEUlAks6zA0HbGGSF2lpjuSZuxPzIBqTyuWof8vFiK6eFAcSXb0hTYIVH3RsTihhfc6G3NRnHoBrzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-shared-contexts": {
+			"version": "9.26.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
+			"integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-theme": "^9.2.1",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-skeleton": {
+			"version": "9.7.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.2.tgz",
+			"integrity": "sha512-PrUgdSGDAZw9FIP5NyvPoPfHDe2N9VxMyBfyTwWfZVg03dzRfnE3vEqr7N5xyfv4JsRs6u1xSqVn/0jdS0IEMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-slider": {
+			"version": "9.6.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.2.tgz",
+			"integrity": "sha512-lVavtTg8eqovfRokeYDk4popwCi8nuicacJ/HZdF3ni5e3y/2WT/bVP0eErS/GvC7+90ACQQ8uxdr4sjjY/HWA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-spinbutton": {
+			"version": "9.6.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.2.tgz",
+			"integrity": "sha512-P4vvJH7P5yHPFAv6aSo3dZxtErN62DiRJN+nEKS+/XBoRGsOGQdqyyx5Q/PQKOmyQrtwuZdXNHUjcyv8b50T2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-spinner": {
+			"version": "9.8.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.2.tgz",
+			"integrity": "sha512-0LxykLJGUD/I3XEeIXAWznwdg9XRe0piaByR0nLFOOV3UPwkVc2w5UdPhy2Y0NZDvtPHbNaMCuQAq82+bxg/0w==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-label": "^9.4.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-swatch-picker": {
+			"version": "9.5.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.2.tgz",
+			"integrity": "sha512-DK6UU9OJY9XaGBPU2ROx+B5/7XdwVtHBdVthOAptyKSsYGOdQt5AQqg3ZOXH6r5WYbMRQDuP2OZ2iKtwidFCVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-switch": {
+			"version": "9.7.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.2.tgz",
+			"integrity": "sha512-j3e5se+3d+befV9MytkxxvJ9nHZOeZ7thKDTF4YVSYf6kcNx9eOlLvPgDjhGO08gzngO4B7aaprhDN7DJc3W1g==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-label": "^9.4.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-table": {
+			"version": "9.19.15",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.15.tgz",
+			"integrity": "sha512-OdQ2Nwx2nAlPMlJeyAFrKa3Zy5Ya/H87OU8MvtFJhabM/FkHiZoli/DO1mavVI+jqavOlJuQWmJ55D6jjuGa7g==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-avatar": "^9.11.1",
+				"@fluentui/react-checkbox": "^9.6.1",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-radio": "^9.6.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-tabs": {
+			"version": "9.12.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.1.tgz",
+			"integrity": "sha512-WvzOtpC6C/7Mo5X+xmE+3stpCbx2iH9BqrEN5KuGrsHJ78DjMDeabYeL90vlrHBdP4VlTpwdORBui/jtWkxnmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-tabster": {
+			"version": "9.26.14",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.14.tgz",
+			"integrity": "sha512-WibgoF67hl6BXfmsY6RSIWSHadeMP/6EDG9gAacfHlwKvK0+FiHp5ernwuXTPAmu2kiHicn2qUZ8EteCFiFryg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1",
+				"keyborg": "^2.6.0",
+				"tabster": "^8.5.5"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-tag-picker": {
+			"version": "9.8.6",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.8.6.tgz",
+			"integrity": "sha512-sOZ+wBA3hgGhKrOP7wbjB2yRvAxjcRXtcj1jDTrtSkaDPXb3K0nGmjiqp2mve995ps3wvCGnNKK4EurX842ZbA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-combobox": "^9.17.1",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-positioning": "^9.22.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-tags": "^9.8.1",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-tags": {
+			"version": "9.8.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.8.1.tgz",
+			"integrity": "sha512-6ZTW78fu5eWByKHIM3i+raDrX3hwfZ67ONfZ8wEUXfZHowskxqpMHI8Gw7IAMWkC1scgLqEnht8TnHvZgjo7Ug==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-avatar": "^9.11.1",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-teaching-popover": {
+			"version": "9.6.21",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.21.tgz",
+			"integrity": "sha512-V86zLB1B8xu3U/02FvvMdsJP+ZC9l3vT9bQ2Gr7hZHxJ4/0NLpVcrYSBFHpON9e/WK3p+A5b5V96p86b5Pavlg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-button": "^9.9.1",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-popover": "^9.14.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-text": {
+			"version": "9.6.16",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.16.tgz",
+			"integrity": "sha512-ZzCSJWQ6LrVuPqA6sqNEZaXbLvhi2NxBOtlMudWlqYzidLQp038d7mMGSzNnhyeblg+gj+bOVE2eOgWFuVHGYw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-textarea": {
+			"version": "9.7.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.2.tgz",
+			"integrity": "sha512-awlkZoW81WaOqSoXTT9rZs3mTAzCCHnC9eAm6J8ZxI5+ASX07BTolBfZ82it5wxOHI5GMDfbFOl+xIy8uAMdzA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-theme": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
+			"integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/tokens": "1.0.0-alpha.23",
+				"@swc/helpers": "^0.5.1"
+			}
+		},
+		"node_modules/@fluentui/react-timepicker-compat": {
+			"version": "0.4.34",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-timepicker-compat/-/react-timepicker-compat-0.4.34.tgz",
+			"integrity": "sha512-G0As6kh5uzDHv68/lJSVfBiAN8Qn6KmWL6wIsvVKt/aezVbsr1X9SaYL/lOG3+qa1m+ZiLqmDUVuBPsC9PK29w==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-combobox": "^9.17.1",
+				"@fluentui/react-field": "^9.5.1",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <20.0.0",
+				"@types/react-dom": ">=16.8.0 <20.0.0",
+				"react": ">=16.8.0 <20.0.0",
+				"react-dom": ">=16.8.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-toast": {
+			"version": "9.7.17",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.7.17.tgz",
+			"integrity": "sha512-DWA5EARWSo1k19iWAulLpKrcUHT+Dq/Bw9zfdpoQEWWybrAZwyN7WiYFkBjKCQRxSp10OjLASSQK91CXfb1wJA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-motion-components-preview": "^0.15.4",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-toolbar": {
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.8.0.tgz",
+			"integrity": "sha512-EIe+QWOaFR1pZzENefsFTmjxGa2yJb4A/by3kGuGqSjx7isqPUllPq0/kFQzfoUYgPDJbJtQ+KyuRDekTL0QpQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-button": "^9.9.1",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-divider": "^9.7.1",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-radio": "^9.6.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-tooltip": {
+			"version": "9.10.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.1.tgz",
+			"integrity": "sha512-IPHBFjqGhaaMDhLt5NSNOE9LEpDOpT7qgEqNz+Mlflo0A4qI2LW/EnkNop7IRmX/bC88A+wUtEONTjjR87dNBw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-portal": "^9.8.12",
+				"@fluentui/react-positioning": "^9.22.1",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-tree": {
+			"version": "9.16.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.16.0.tgz",
+			"integrity": "sha512-c+Q4AVaYk9U69aGDgmJVNne+CtWKS75YIfGoxs6+9+wE2Wqz4T0E+gE1ng7ARCQQgI7E2NEJlot6DuI6nYYrRw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-aria": "^9.17.11",
+				"@fluentui/react-avatar": "^9.11.1",
+				"@fluentui/react-button": "^9.9.1",
+				"@fluentui/react-checkbox": "^9.6.1",
+				"@fluentui/react-context-selector": "^9.2.16",
+				"@fluentui/react-icons": "^2.0.245",
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-motion": "^9.15.0",
+				"@fluentui/react-motion-components-preview": "^0.15.4",
+				"@fluentui/react-radio": "^9.6.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-tabster": "^9.26.14",
+				"@fluentui/react-theme": "^9.2.1",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-utilities": {
+			"version": "9.26.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.3.tgz",
+			"integrity": "sha512-bXB3jMm/RroT8c5eGZkijkPbLd4MqMI6biBHjavo0e7OkZHv9IPfH2nDkGhSn5Sh8e6kRcX0IjYhbM10WUK2iQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/keyboard-keys": "^9.0.8",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-virtualizer": {
+			"version": "9.0.0-alpha.112",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.112.tgz",
+			"integrity": "sha512-dao/mQssaPFxCXMx7K+G/DrRoZg28kXcE1NGbJ1RPtbkVCzJgwrEEeDhM5/wyOXO/Z5EZ31FIerDDVOyr6FAaw==",
+			"license": "MIT",
+			"dependencies": {
+				"@fluentui/react-jsx-runtime": "^9.4.2",
+				"@fluentui/react-shared-contexts": "^9.26.2",
+				"@fluentui/react-utilities": "^9.26.3",
+				"@griffel/react": "^1.5.32",
+				"@swc/helpers": "^0.5.1"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.14.0 <20.0.0",
+				"@types/react-dom": ">=16.9.0 <20.0.0",
+				"react": ">=16.14.0 <20.0.0",
+				"react-dom": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@fluentui/tokens": {
+			"version": "1.0.0-alpha.23",
+			"resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
+			"integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@swc/helpers": "^0.5.1"
+			}
+		},
+		"node_modules/@griffel/core": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.0.tgz",
+			"integrity": "sha512-QqMoewiNTT0DmLM7OY607c7yhg18SuKfzovTO3hPXGQvtdu/StnjvuBAs+1B1kYSVGReAo6s/dJVeLnPuHjE7Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/hash": "^0.9.0",
+				"@griffel/style-types": "^1.4.0",
+				"csstype": "^3.1.3",
+				"rtl-css-js": "^1.16.1",
+				"stylis": "^4.4.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@griffel/react": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.7.2.tgz",
+			"integrity": "sha512-/+N+81e9ibNsh2wNlhGf2PcimEFrx8VbtWiLCmI6lsrTV5eBcQrIIDVQq737KPIJFtD4v6Txu9n0PXbN3hedNg==",
+			"license": "MIT",
+			"dependencies": {
+				"@griffel/core": "^1.21.0",
+				"tslib": "^2.1.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.14.0 <20.0.0"
+			}
+		},
+		"node_modules/@griffel/style-types": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.0.tgz",
+			"integrity": "sha512-vNDfOGV7RN/XkA7vxgf7Z5HgW8eiBm5cHT9wQPhsKB4pxWom5u6eQ9CkYE5mCCTSPl9H6Nd1NBai04d4P6BD7Q==",
+			"license": "MIT",
+			"dependencies": {
+				"csstype": "^3.1.3"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@monaco-editor/loader": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+			"integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+			"license": "MIT",
+			"dependencies": {
+				"state-local": "^1.0.6"
+			}
+		},
+		"node_modules/@monaco-editor/react": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+			"integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+			"license": "MIT",
+			"dependencies": {
+				"@monaco-editor/loader": "^1.5.0"
+			},
+			"peerDependencies": {
+				"monaco-editor": ">= 0.25.0 < 1",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@pptb/types": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@pptb/types/-/types-1.2.1.tgz",
+			"integrity": "sha512-U8/Tij6CB09T+g/lE3gubdNnw7wmHz4LKoaWCMiXsv6BTNliXD99Wt6XW1K7WWdUwhIknKK9Jor3YhzoboVhHA==",
+			"dev": true,
+			"license": "GPL-3.0",
+			"bin": {
+				"pptb-validate": "bin/pptb-validate.js"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+			"integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+			"integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+			"integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+			"integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+			"integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+			"integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+			"integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+			"integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+			"integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+			"integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+			"integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+			"integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+			"integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+			"integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+			"integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+			"integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+			"integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+			"integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+			"integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+			"integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+			"integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+			"integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+			"integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+			"integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+			"integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+			"integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@swc/helpers": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+			"integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.8.0"
+			}
+		},
+		"node_modules/@types/babel__core": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.20.7",
+				"@babel/types": "^7.20.7",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"node_modules/@types/babel__generator": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__traverse": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.28.2"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/react": {
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"csstype": "^3.2.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
+			}
+		},
+		"node_modules/@vitejs/plugin-react": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+			"integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.29.0",
+				"@babel/plugin-transform-react-jsx-self": "^7.27.1",
+				"@babel/plugin-transform-react-jsx-source": "^7.27.1",
+				"@rolldown/pluginutils": "1.0.0-rc.3",
+				"@types/babel__core": "^7.20.5",
+				"react-refresh": "^0.18.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.27",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+			"integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/browserslist": {
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001791",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+			"integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "CC-BY-4.0"
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/csstype": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"license": "MIT"
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+			"integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+			"license": "(MPL-2.0 OR Apache-2.0)"
+		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.351",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.351.tgz",
+			"integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/embla-carousel": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+			"integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+			"license": "MIT"
+		},
+		"node_modules/embla-carousel-autoplay": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+			"integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"embla-carousel": "8.6.0"
+			}
+		},
+		"node_modules/embla-carousel-fade": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+			"integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"embla-carousel": "8.6.0"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"license": "MIT"
+		},
+		"node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/keyborg": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.14.1.tgz",
+			"integrity": "sha512-/WmmVBa6Me3hIKAOIyIq1sql+6oydQZzGMBDLNfOcJ8710byMsq3KSLS8GQhBJHOMtvnXnUBrDAIbABcZVipcg==",
+			"license": "MIT"
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/marked": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+			"integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/memoize-one": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+			"integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+			"license": "MIT"
+		},
+		"node_modules/monaco-editor": {
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
+			"integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+			"license": "MIT",
+			"dependencies": {
+				"dompurify": "3.1.7",
+				"marked": "14.0.0"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.38",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+			"integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/react": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-dom": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.2"
+			},
+			"peerDependencies": {
+				"react": "^18.3.1"
+			}
+		},
+		"node_modules/react-dom/node_modules/scheduler": {
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
+		},
+		"node_modules/react-refresh": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+			"integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-window": {
+			"version": "1.8.11",
+			"resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+			"integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.0.0",
+				"memoize-one": ">=3.1.1 <6"
+			},
+			"engines": {
+				"node": ">8.0.0"
+			},
+			"peerDependencies": {
+				"react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.60.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+			"integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.8"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.60.3",
+				"@rollup/rollup-android-arm64": "4.60.3",
+				"@rollup/rollup-darwin-arm64": "4.60.3",
+				"@rollup/rollup-darwin-x64": "4.60.3",
+				"@rollup/rollup-freebsd-arm64": "4.60.3",
+				"@rollup/rollup-freebsd-x64": "4.60.3",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+				"@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+				"@rollup/rollup-linux-arm64-gnu": "4.60.3",
+				"@rollup/rollup-linux-arm64-musl": "4.60.3",
+				"@rollup/rollup-linux-loong64-gnu": "4.60.3",
+				"@rollup/rollup-linux-loong64-musl": "4.60.3",
+				"@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+				"@rollup/rollup-linux-ppc64-musl": "4.60.3",
+				"@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+				"@rollup/rollup-linux-riscv64-musl": "4.60.3",
+				"@rollup/rollup-linux-s390x-gnu": "4.60.3",
+				"@rollup/rollup-linux-x64-gnu": "4.60.3",
+				"@rollup/rollup-linux-x64-musl": "4.60.3",
+				"@rollup/rollup-openbsd-x64": "4.60.3",
+				"@rollup/rollup-openharmony-arm64": "4.60.3",
+				"@rollup/rollup-win32-arm64-msvc": "4.60.3",
+				"@rollup/rollup-win32-ia32-msvc": "4.60.3",
+				"@rollup/rollup-win32-x64-gnu": "4.60.3",
+				"@rollup/rollup-win32-x64-msvc": "4.60.3",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/rtl-css-js": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+			"integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.1.2"
+			}
+		},
+		"node_modules/scheduler": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/state-local": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+			"integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+			"license": "MIT"
+		},
+		"node_modules/stylis": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+			"integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+			"license": "MIT"
+		},
+		"node_modules/tabster": {
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/tabster/-/tabster-8.8.0.tgz",
+			"integrity": "sha512-eGFXgtvKOQP5BywDI9Ngs+Atm6TRj45epAAqWKyVoi+HmOmdamEB//1H/FttLdNly/+Cz+GJ4RN8TnXTw0KwfA==",
+			"license": "MIT",
+			"dependencies": {
+				"keyborg": "^2.14.0",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/vite": {
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+			"integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.27.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true,
+			"license": "ISC"
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mohsinonxrm/pptb-dataverse-request-studio",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/src/engine/odataParser.ts
+++ b/src/engine/odataParser.ts
@@ -390,15 +390,36 @@ async function validateFilterColumns(
       if (col.includes('/')) {
         const segs = col.split('/');
         let cursor: TableMeta | undefined = ownerTable;
+        let badHop: string | undefined;
+        let timedOutEntity: string | undefined;
         for (let i = 0; i < segs.length - 1; i++) {
           if (!cursor) break;
           const nav: NavProperty | undefined = cursor.navigationProperties.find(
             (n: NavProperty) => n.name === segs[i] && n.cardinality === 'ManyToOne',
           );
-          if (!nav) { cursor = undefined; break; }
-          cursor = await loadTableWithTimeout(loadTable, nav.targetEntity);
+          if (!nav) {
+            badHop = `\`${segs[i]}\` is not a ManyToOne navigation on \`${cursor.logicalName}\``;
+            cursor = undefined;
+            break;
+          }
+          const next = await loadTableWithTimeout(loadTable, nav.targetEntity);
+          if (!next) {
+            timedOutEntity = nav.targetEntity;
+            cursor = undefined;
+            break;
+          }
+          cursor = next;
         }
-        if (cursor) {
+        if (badHop) {
+          warnings.push(iss(
+            `$filter: nav path \`${col}\` — ${badHop}.`,
+            DOCS.filterRows,
+          ));
+        } else if (timedOutEntity) {
+          warnings.push(iss(
+            `$filter: couldn't validate \`${col}\` — metadata for \`${timedOutEntity}\` timed out.`,
+          ));
+        } else if (cursor) {
           const leaf = segs[segs.length - 1];
           if (!columnExistsOnTable(cursor, leaf)) {
             warnings.push(iss(

--- a/src/engine/odataParser.ts
+++ b/src/engine/odataParser.ts
@@ -31,32 +31,36 @@
 //   ⚠️ `$search`, `$format`, `$skiptoken` — Dataverse doesn't support these
 //      and DRS doesn't model them. Skipped silently.
 
-import type { TableMeta, NavProperty } from '../mock/metadata';
-import { findTable } from '../mock/metadata';
+import type { TableMeta, NavProperty } from "../mock/metadata";
+import { findTable } from "../mock/metadata";
 import type {
-  FilterGroup, FilterNode, FilterRule, FilterFunctionNode, FilterLambdaNode,
-} from '../editors/filter/filterTree';
-import { newId } from '../editors/filter/filterTree';
-import { findOperator, OPERATORS } from '../editors/filter/operators';
-import type { ExpandSpec } from '../editors/ExpandEditor';
-import { makeExpandSpec } from '../editors/ExpandEditor';
-import type { OrderbySpec } from '../editors/OrderbyEditor';
-import type { ApplySpec, ApplyAgg, AggFn } from '../editors/ApplyEditor';
+	FilterGroup,
+	FilterNode,
+	FilterRule,
+	FilterFunctionNode,
+	FilterLambdaNode,
+} from "../editors/filter/filterTree";
+import { newId } from "../editors/filter/filterTree";
+import { findOperator, OPERATORS } from "../editors/filter/operators";
+import type { ExpandSpec } from "../editors/ExpandEditor";
+import { makeExpandSpec } from "../editors/ExpandEditor";
+import type { OrderbySpec } from "../editors/OrderbyEditor";
+import type { ApplySpec, ApplyAgg, AggFn } from "../editors/ApplyEditor";
 
 // ── Public surface ──────────────────────────────────────────────────────
 
 export interface ParsedRequest {
-  /** Logical name (e.g. 'account'), resolved from entitySetName. Empty when the entity is unknown. */
-  table: string;
-  /** Entity-set name as it appeared in the URL (e.g. 'accounts'). */
-  entitySet: string;
-  select: string[];
-  filter: FilterGroup;
-  orderby: OrderbySpec[];
-  top: number | null;
-  countOn: boolean;
-  expand: ExpandSpec[];
-  apply?: ApplySpec;
+	/** Logical name (e.g. 'account'), resolved from entitySetName. Empty when the entity is unknown. */
+	table: string;
+	/** Entity-set name as it appeared in the URL (e.g. 'accounts'). */
+	entitySet: string;
+	select: string[];
+	filter: FilterGroup;
+	orderby: OrderbySpec[];
+	top: number | null;
+	countOn: boolean;
+	expand: ExpandSpec[];
+	apply?: ApplySpec;
 }
 
 /**
@@ -66,45 +70,55 @@ export interface ParsedRequest {
  * enumerate every value in the message itself.
  */
 export interface ParseIssue {
-  message: string;
-  /** Optional MS Learn deep link for the user to verify our claim. */
-  learnMoreUrl?: string;
+	message: string;
+	/** Optional MS Learn deep link for the user to verify our claim. */
+	learnMoreUrl?: string;
 }
 
 export interface ParseResult {
-  ok: boolean;
-  parsed?: ParsedRequest;
-  /** Lossy-but-legal constructs DRS can still represent. Don't block apply. */
-  warnings: ParseIssue[];
-  /** Things DRS can't faithfully represent. Block apply. */
-  errors: ParseIssue[];
+	ok: boolean;
+	parsed?: ParsedRequest;
+	/** Lossy-but-legal constructs DRS can still represent. Don't block apply. */
+	warnings: ParseIssue[];
+	/** Things DRS can't faithfully represent. Block apply. */
+	errors: ParseIssue[];
 }
 
 // MS Learn deep links for common error categories — used as `learnMoreUrl`.
 const DOCS = {
-  queryFunctions: 'https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/queryfunctions',
-  filterRows:     'https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query/filter-rows',
-  aggregateData:  'https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query/aggregate-data',
-  queryOptions:   'https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query-data-web-api',
-  joinTables:     'https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query/join-tables',
-  attrMetadata:   'https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/use-web-api-functions#address-lookup-and-customer-fields-in-functions',
+	queryFunctions:
+		"https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/queryfunctions",
+	filterRows:
+		"https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query/filter-rows",
+	aggregateData:
+		"https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query/aggregate-data",
+	queryOptions:
+		"https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query-data-web-api",
+	joinTables:
+		"https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query/join-tables",
+	attrMetadata:
+		"https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/use-web-api-functions#address-lookup-and-customer-fields-in-functions",
 };
 
 /** Internal — throw from any sub-parser to carry a learn-more URL up through
  *  the top-level catch. */
 class ParseFailure extends Error {
-  constructor(message: string, public learnMoreUrl?: string) {
-    super(message);
-  }
+	constructor(
+		message: string,
+		public learnMoreUrl?: string,
+	) {
+		super(message);
+	}
 }
 
 /** Short constructor for ParseIssue. */
-const iss = (message: string, learnMoreUrl?: string): ParseIssue =>
-  ({ message, learnMoreUrl });
+const iss = (message: string, learnMoreUrl?: string): ParseIssue => ({ message, learnMoreUrl });
 
 /** Prefix the message of an existing issue, preserving its learnMoreUrl. */
-const prefixIss = (prefix: string, i: ParseIssue): ParseIssue =>
-  ({ message: `${prefix}: ${i.message}`, learnMoreUrl: i.learnMoreUrl });
+const prefixIss = (prefix: string, i: ParseIssue): ParseIssue => ({
+	message: `${prefix}: ${i.message}`,
+	learnMoreUrl: i.learnMoreUrl,
+});
 
 /**
  * Resolve an entity-set name (e.g. 'accounts') to a logical name (e.g. 'account').
@@ -124,18 +138,25 @@ export type LoadTable = (logical: string) => Promise<TableMeta | undefined>;
 
 /** OData / Dataverse query options DRS understands. Anything else is rejected. */
 const KNOWN_QUERY_OPTIONS = new Set([
-  '$select', '$filter', '$orderby', '$top', '$skip', '$count', '$expand', '$apply',
+	"$select",
+	"$filter",
+	"$orderby",
+	"$top",
+	"$skip",
+	"$count",
+	"$expand",
+	"$apply",
 ]);
 
 /** Every Dataverse query function defined in the operator registry. */
 const KNOWN_DV_FUNCTIONS = new Set(
-  OPERATORS.filter(o => o.kind.startsWith('dv-fn-')).map(o => o.id),
+	OPERATORS.filter((o) => o.kind.startsWith("dv-fn-")).map((o) => o.id),
 );
 
 /** Aggregate functions DRS's ApplyEditor can model. `countdistinct` is
  *  valid OData but not modeled by DRS — pasted requests using it must be
  *  rewritten manually. */
-const KNOWN_AGG_FNS = new Set(['sum', 'average', 'min', 'max', '$count']);
+const KNOWN_AGG_FNS = new Set(["sum", "average", "min", "max", "$count"]);
 
 // ── Top-level entry point ───────────────────────────────────────────────
 
@@ -155,107 +176,121 @@ const KNOWN_AGG_FNS = new Set(['sum', 'average', 'min', 'max', '$count']);
  * → drop the `not`, function preserved — query still works).
  */
 export async function parseODataUrl(
-  rawUrl: string,
-  resolveEntitySet: EntitySetResolver,
-  loadTable?: LoadTable,
+	rawUrl: string,
+	resolveEntitySet: EntitySetResolver,
+	loadTable?: LoadTable,
 ): Promise<ParseResult> {
-  const warnings: ParseIssue[] = [];
-  const errors: ParseIssue[] = [];
-  try {
-    const { entitySet, query } = splitUrl(rawUrl);
-    if (!entitySet) {
-      errors.push(iss('Could not extract an entity-set name from the URL.', DOCS.queryOptions));
-      return { ok: false, warnings, errors };
-    }
+	const warnings: ParseIssue[] = [];
+	const errors: ParseIssue[] = [];
+	try {
+		const { entitySet, query } = splitUrl(rawUrl);
+		if (!entitySet) {
+			errors.push(iss("Could not extract an entity-set name from the URL.", DOCS.queryOptions));
+			return { ok: false, warnings, errors };
+		}
 
-    // ── Static: entity set resolution ──
-    const table = resolveEntitySet(entitySet) ?? '';
-    if (!table) {
-      errors.push(iss(
-        `Entity set '${entitySet}' is not a known entity in this environment.`,
-        DOCS.queryOptions,
-      ));
-      return { ok: false, warnings, errors };
-    }
-    const tbl = findTable(table);
+		// ── Static: entity set resolution ──
+		const table = resolveEntitySet(entitySet) ?? "";
+		if (!table) {
+			errors.push(
+				iss(
+					`Entity set '${entitySet}' is not a known entity in this environment.`,
+					DOCS.queryOptions,
+				),
+			);
+			return { ok: false, warnings, errors };
+		}
+		const tbl = findTable(table);
 
-    const opts = splitQueryOptions(query);
+		const opts = splitQueryOptions(query);
 
-    // ── Static: unknown query options ──
-    for (const k of Object.keys(opts)) {
-      if (!KNOWN_QUERY_OPTIONS.has(k)) {
-        errors.push(iss(
-          `Unknown query option \`${k}\` — not part of DRS's supported set.`,
-          DOCS.queryOptions,
-        ));
-      }
-    }
-    if (errors.length) return { ok: false, warnings, errors };
+		// ── Static: unknown query options ──
+		for (const k of Object.keys(opts)) {
+			if (!KNOWN_QUERY_OPTIONS.has(k)) {
+				errors.push(
+					iss(
+						`Unknown query option \`${k}\` — not part of DRS's supported set.`,
+						DOCS.queryOptions,
+					),
+				);
+			}
+		}
+		if (errors.length) return { ok: false, warnings, errors };
 
-    // ── Scalars ──
-    const top = opts.$top ? parseIntOrNull(opts.$top) : null;
-    const countOn = opts.$count === 'true';
+		// ── Scalars ──
+		const top = opts.$top ? parseIntOrNull(opts.$top) : null;
+		const countOn = opts.$count === "true";
 
-    // ── $select ──
-    const select = opts.$select ? parseSelect(opts.$select, tbl) : [];
+		// ── $select ──
+		const select = opts.$select ? parseSelect(opts.$select, tbl) : [];
 
-    // ── $orderby ──
-    const orderby = opts.$orderby ? parseOrderby(opts.$orderby, tbl) : [];
+		// ── $orderby ──
+		const orderby = opts.$orderby ? parseOrderby(opts.$orderby, tbl) : [];
 
-    // ── $filter ── (collects its own errors for unknown DV functions)
-    let filter: FilterGroup = emptyFilterGroup();
-    if (opts.$filter) {
-      const r = parseFilter(opts.$filter, tbl);
-      filter = r.group;
-      warnings.push(...r.warnings);
-      errors.push(...r.errors);
-    }
+		// ── $filter ── (collects its own errors for unknown DV functions)
+		let filter: FilterGroup = emptyFilterGroup();
+		if (opts.$filter) {
+			const r = parseFilter(opts.$filter, tbl);
+			filter = r.group;
+			warnings.push(...r.warnings);
+			errors.push(...r.errors);
+		}
 
-    // ── $expand ──
-    let expand: ExpandSpec[] = [];
-    if (opts.$expand) {
-      const r = parseExpand(opts.$expand, tbl);
-      expand = r.items;
-      warnings.push(...r.warnings);
-      errors.push(...r.errors);
-    }
+		// ── $expand ──
+		let expand: ExpandSpec[] = [];
+		if (opts.$expand) {
+			const r = parseExpand(opts.$expand, tbl);
+			expand = r.items;
+			warnings.push(...r.warnings);
+			errors.push(...r.errors);
+		}
 
-    // ── $apply ──
-    let apply: ApplySpec | undefined;
-    if (opts.$apply) {
-      const r = parseApply(opts.$apply, tbl);
-      apply = r.spec;
-      warnings.push(...r.warnings);
-      errors.push(...r.errors);
-    }
+		// ── $apply ──
+		let apply: ApplySpec | undefined;
+		if (opts.$apply) {
+			const r = parseApply(opts.$apply, tbl);
+			apply = r.spec;
+			warnings.push(...r.warnings);
+			errors.push(...r.errors);
+		}
 
-    // If any sub-parser flagged a hard error, bail before semantic validation.
-    if (errors.length) return { ok: false, warnings, errors };
+		// If any sub-parser flagged a hard error, bail before semantic validation.
+		if (errors.length) return { ok: false, warnings, errors };
 
-    const parsed: ParsedRequest = { table, entitySet, select, filter, orderby, top, countOn, expand, apply };
+		const parsed: ParsedRequest = {
+			table,
+			entitySet,
+			select,
+			filter,
+			orderby,
+			top,
+			countOn,
+			expand,
+			apply,
+		};
 
-    // ── Semantic validation (async) ──
-    // Loads metadata for every involved entity and checks column / nav
-    // references exist. If loadTable wasn't supplied (e.g. unit tests),
-    // we skip this phase entirely — orphans surface in the editors later.
-    if (loadTable) {
-      await validateAgainstMetadata(parsed, loadTable, errors, warnings);
-    }
+		// ── Semantic validation (async) ──
+		// Loads metadata for every involved entity and checks column / nav
+		// references exist. If loadTable wasn't supplied (e.g. unit tests),
+		// we skip this phase entirely — orphans surface in the editors later.
+		if (loadTable) {
+			await validateAgainstMetadata(parsed, loadTable, errors, warnings);
+		}
 
-    return {
-      ok: errors.length === 0,
-      parsed: errors.length === 0 ? parsed : undefined,
-      warnings,
-      errors,
-    };
-  } catch (e) {
-    if (e instanceof ParseFailure) {
-      errors.push(iss(e.message, e.learnMoreUrl));
-    } else {
-      errors.push(iss(e instanceof Error ? e.message : String(e), DOCS.filterRows));
-    }
-    return { ok: false, warnings, errors };
-  }
+		return {
+			ok: errors.length === 0,
+			parsed: errors.length === 0 ? parsed : undefined,
+			warnings,
+			errors,
+		};
+	} catch (e) {
+		if (e instanceof ParseFailure) {
+			errors.push(iss(e.message, e.learnMoreUrl));
+		} else {
+			errors.push(iss(e instanceof Error ? e.message : String(e), DOCS.filterRows));
+		}
+		return { ok: false, warnings, errors };
+	}
 }
 
 // ── Semantic validator (uses async-loaded metadata) ─────────────────────
@@ -266,91 +301,107 @@ export async function parseODataUrl(
  * caller emits a warning and skips that entity's validation.
  */
 async function loadTableWithTimeout(
-  loadTable: LoadTable,
-  logical: string,
-  timeoutMs = 15000,
+	loadTable: LoadTable,
+	logical: string,
+	timeoutMs = 15000,
 ): Promise<TableMeta | undefined> {
-  return Promise.race([
-    loadTable(logical),
-    new Promise<undefined>(resolve => setTimeout(() => resolve(undefined), timeoutMs)),
-  ]);
+	return Promise.race([
+		loadTable(logical),
+		new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), timeoutMs)),
+	]);
 }
 
 async function validateAgainstMetadata(
-  parsed: ParsedRequest,
-  loadTable: LoadTable,
-  errors: ParseIssue[],
-  warnings: ParseIssue[],
+	parsed: ParsedRequest,
+	loadTable: LoadTable,
+	errors: ParseIssue[],
+	warnings: ParseIssue[],
 ): Promise<void> {
-  const rootTbl = await loadTableWithTimeout(loadTable, parsed.table);
-  if (!rootTbl) {
-    warnings.push(iss(
-      `Metadata for \`${parsed.table}\` could not be loaded (or timed out) — column validation skipped.`,
-    ));
-    return;
-  }
+	const rootTbl = await loadTableWithTimeout(loadTable, parsed.table);
+	if (!rootTbl) {
+		warnings.push(
+			iss(
+				`Metadata for \`${parsed.table}\` could not be loaded (or timed out) — column validation skipped.`,
+			),
+		);
+		return;
+	}
 
-  // ── $select on root ──
-  for (const c of parsed.select) {
-    if (!columnExistsOnTable(rootTbl, c)) {
-      errors.push(iss(
-        `$select: column \`${c}\` does not exist on \`${parsed.table}\`.`,
-        DOCS.attrMetadata,
-      ));
-    }
-  }
+	// ── $select on root ──
+	for (const c of parsed.select) {
+		if (!columnExistsOnTable(rootTbl, c)) {
+			errors.push(
+				iss(`$select: column \`${c}\` does not exist on \`${parsed.table}\`.`, DOCS.attrMetadata),
+			);
+		}
+	}
 
-  // ── $orderby on root ──
-  for (const o of parsed.orderby) {
-    if (!columnExistsOnTable(rootTbl, o.col)) {
-      errors.push(iss(
-        `$orderby: column \`${o.col}\` does not exist on \`${parsed.table}\`.`,
-        DOCS.attrMetadata,
-      ));
-    }
-  }
+	// ── $orderby on root ──
+	for (const o of parsed.orderby) {
+		if (!columnExistsOnTable(rootTbl, o.col)) {
+			errors.push(
+				iss(
+					`$orderby: column \`${o.col}\` does not exist on \`${parsed.table}\`.`,
+					DOCS.attrMetadata,
+				),
+			);
+		}
+	}
 
-  // ── $filter rule columns (recursive — walks lambdas + nested groups) ──
-  await validateFilterColumns(parsed.filter, rootTbl, loadTable, errors, warnings, undefined);
+	// ── $filter rule columns (recursive — walks lambdas + nested groups) ──
+	await validateFilterColumns(parsed.filter, rootTbl, loadTable, errors, warnings, undefined);
 
-  // ── $expand tree (recursive) ──
-  for (const e of parsed.expand) {
-    await validateExpandTree(e, rootTbl, loadTable, errors, warnings);
-  }
+	// ── $expand tree (recursive) ──
+	for (const e of parsed.expand) {
+		await validateExpandTree(e, rootTbl, loadTable, errors, warnings);
+	}
 
-  // ── $apply ──
-  if (parsed.apply?.enabled) {
-    for (const g of parsed.apply.groupby) {
-      const segs = g.split('/');
-      if (segs.length === 1) {
-        if (!columnExistsOnTable(rootTbl, segs[0])) {
-          errors.push(iss(
-            `$apply/groupby: column \`${segs[0]}\` does not exist on \`${parsed.table}\`.`,
-            DOCS.aggregateData,
-          ));
-        }
-      } else {
-        const firstHop = segs[0];
-        const nav = rootTbl.navigationProperties.find(n => n.name === firstHop);
-        if (!nav && !columnExistsOnTable(rootTbl, firstHop)) {
-          errors.push(iss(
-            `$apply/groupby: \`${firstHop}\` is not a column or navigation on \`${parsed.table}\`.`,
-            DOCS.aggregateData,
-          ));
-        }
-      }
-    }
-    for (const a of parsed.apply.aggregates) {
-      if (a.fn !== '$count' && !columnExistsOnTable(rootTbl, a.col)) {
-        errors.push(iss(
-          `$apply/aggregate: column \`${a.col}\` does not exist on \`${parsed.table}\`.`,
-          DOCS.aggregateData,
-        ));
-      }
-    }
-    // Also validate the prefilter (uses same root table).
-    await validateFilterColumns(parsed.apply.prefilter, rootTbl, loadTable, errors, warnings, undefined);
-  }
+	// ── $apply ──
+	if (parsed.apply?.enabled) {
+		for (const g of parsed.apply.groupby) {
+			const segs = g.split("/");
+			if (segs.length === 1) {
+				if (!columnExistsOnTable(rootTbl, segs[0])) {
+					errors.push(
+						iss(
+							`$apply/groupby: column \`${segs[0]}\` does not exist on \`${parsed.table}\`.`,
+							DOCS.aggregateData,
+						),
+					);
+				}
+			} else {
+				const firstHop = segs[0];
+				const nav = rootTbl.navigationProperties.find((n) => n.name === firstHop);
+				if (!nav && !columnExistsOnTable(rootTbl, firstHop)) {
+					errors.push(
+						iss(
+							`$apply/groupby: \`${firstHop}\` is not a column or navigation on \`${parsed.table}\`.`,
+							DOCS.aggregateData,
+						),
+					);
+				}
+			}
+		}
+		for (const a of parsed.apply.aggregates) {
+			if (a.fn !== "$count" && !columnExistsOnTable(rootTbl, a.col)) {
+				errors.push(
+					iss(
+						`$apply/aggregate: column \`${a.col}\` does not exist on \`${parsed.table}\`.`,
+						DOCS.aggregateData,
+					),
+				);
+			}
+		}
+		// Also validate the prefilter (uses same root table).
+		await validateFilterColumns(
+			parsed.apply.prefilter,
+			rootTbl,
+			loadTable,
+			errors,
+			warnings,
+			undefined,
+		);
+	}
 }
 
 /**
@@ -364,145 +415,160 @@ async function validateAgainstMetadata(
  *   • Lambda nav references when the target table can't be loaded.
  */
 async function validateFilterColumns(
-  group: FilterGroup,
-  ownerTable: TableMeta,
-  loadTable: LoadTable,
-  errors: ParseIssue[],
-  warnings: ParseIssue[],
-  lambdaAlias: string | undefined,
+	group: FilterGroup,
+	ownerTable: TableMeta,
+	loadTable: LoadTable,
+	errors: ParseIssue[],
+	warnings: ParseIssue[],
+	lambdaAlias: string | undefined,
 ): Promise<void> {
-  for (const node of group.rules) {
-    if (node.type === 'group') {
-      await validateFilterColumns(node, ownerTable, loadTable, errors, warnings, lambdaAlias);
-    } else if (node.type === 'rule' || node.type === 'function') {
-      let col = node.col;
-      if (!col) continue;
-      // Strip lambda alias prefix
-      if (lambdaAlias && col.startsWith(lambdaAlias + '/')) {
-        col = col.slice(lambdaAlias.length + 1);
-      }
-      // Multi-segment nav-path (e.g. `primarycontactid/abc_salesstage`):
-      // walk the N:1 hops, loading each related entity — which both validates
-      // the leaf AND warms the related metadata so the $filter encoder can
-      // resolve the leaf's type (and avoid string-quoting a numeric/boolean
-      // OptionSet — issue #33). Reported as a warning, not an error, because
-      // a hop may legitimately fail to load within the timeout.
-      if (col.includes('/')) {
-        const segs = col.split('/');
-        let cursor: TableMeta | undefined = ownerTable;
-        let badHop: string | undefined;
-        let timedOutEntity: string | undefined;
-        for (let i = 0; i < segs.length - 1; i++) {
-          if (!cursor) break;
-          const nav: NavProperty | undefined = cursor.navigationProperties.find(
-            (n: NavProperty) => n.name === segs[i] && n.cardinality === 'ManyToOne',
-          );
-          if (!nav) {
-            badHop = `\`${segs[i]}\` is not a ManyToOne navigation on \`${cursor.logicalName}\``;
-            cursor = undefined;
-            break;
-          }
-          const next = await loadTableWithTimeout(loadTable, nav.targetEntity);
-          if (!next) {
-            timedOutEntity = nav.targetEntity;
-            cursor = undefined;
-            break;
-          }
-          cursor = next;
-        }
-        if (badHop) {
-          warnings.push(iss(
-            `$filter: nav path \`${col}\` — ${badHop}.`,
-            DOCS.filterRows,
-          ));
-        } else if (timedOutEntity) {
-          warnings.push(iss(
-            `$filter: couldn't validate \`${col}\` — metadata for \`${timedOutEntity}\` timed out.`,
-          ));
-        } else if (cursor) {
-          const leaf = segs[segs.length - 1];
-          if (!columnExistsOnTable(cursor, leaf)) {
-            warnings.push(iss(
-              `$filter: column \`${leaf}\` not found on \`${cursor.logicalName}\` (via \`${col}\`).`,
-              DOCS.filterRows,
-            ));
-          }
-        }
-        continue;
-      }
-      if (!columnExistsOnTable(ownerTable, col)) {
-        errors.push(iss(
-          `$filter: column \`${col}\` does not exist on \`${ownerTable.logicalName}\`.`,
-          DOCS.filterRows,
-        ));
-      }
-    } else if (node.type === 'lambda') {
-      const nav = ownerTable.navigationProperties.find(n => n.name === node.nav);
-      if (!nav) {
-        errors.push(iss(
-          `$filter lambda: nav \`${node.nav}\` does not exist on \`${ownerTable.logicalName}\`.`,
-          DOCS.filterRows,
-        ));
-        continue;
-      }
-      const targetTbl = await loadTableWithTimeout(loadTable, nav.targetEntity);
-      if (!targetTbl) {
-        warnings.push(iss(
-          `Metadata for \`${nav.targetEntity}\` (lambda target via \`${node.nav}\`) could not be loaded — inner filter not column-validated.`,
-        ));
-        continue;
-      }
-      await validateFilterColumns(node.inner, targetTbl, loadTable, errors, warnings, node.alias);
-    }
-  }
+	for (const node of group.rules) {
+		if (node.type === "group") {
+			await validateFilterColumns(node, ownerTable, loadTable, errors, warnings, lambdaAlias);
+		} else if (node.type === "rule" || node.type === "function") {
+			let col = node.col;
+			if (!col) continue;
+			// Strip lambda alias prefix
+			if (lambdaAlias && col.startsWith(lambdaAlias + "/")) {
+				col = col.slice(lambdaAlias.length + 1);
+			}
+			// Multi-segment nav-path (e.g. `primarycontactid/abc_salesstage`):
+			// walk the N:1 hops, loading each related entity — which both validates
+			// the leaf AND warms the related metadata so the $filter encoder can
+			// resolve the leaf's type (and avoid string-quoting a numeric/boolean
+			// OptionSet — issue #33). Reported as a warning, not an error, because
+			// a hop may legitimately fail to load within the timeout.
+			if (col.includes("/")) {
+				const segs = col.split("/");
+				let cursor: TableMeta | undefined = ownerTable;
+				let badHop: string | undefined;
+				let timedOutEntity: string | undefined;
+				for (let i = 0; i < segs.length - 1; i++) {
+					if (!cursor) break;
+					const nav: NavProperty | undefined = cursor.navigationProperties.find(
+						(n: NavProperty) => n.name === segs[i] && n.cardinality === "ManyToOne",
+					);
+					if (!nav) {
+						badHop = `\`${segs[i]}\` is not a ManyToOne navigation on \`${cursor.logicalName}\``;
+						cursor = undefined;
+						break;
+					}
+					const next = await loadTableWithTimeout(loadTable, nav.targetEntity);
+					if (!next) {
+						timedOutEntity = nav.targetEntity;
+						cursor = undefined;
+						break;
+					}
+					cursor = next;
+				}
+				if (badHop) {
+					warnings.push(iss(`$filter: nav path \`${col}\` — ${badHop}.`, DOCS.filterRows));
+				} else if (timedOutEntity) {
+					warnings.push(
+						iss(
+							`$filter: couldn't validate \`${col}\` — metadata for \`${timedOutEntity}\` timed out.`,
+						),
+					);
+				} else if (cursor) {
+					const leaf = segs[segs.length - 1];
+					if (!columnExistsOnTable(cursor, leaf)) {
+						warnings.push(
+							iss(
+								`$filter: column \`${leaf}\` not found on \`${cursor.logicalName}\` (via \`${col}\`).`,
+								DOCS.filterRows,
+							),
+						);
+					}
+				}
+				continue;
+			}
+			if (!columnExistsOnTable(ownerTable, col)) {
+				errors.push(
+					iss(
+						`$filter: column \`${col}\` does not exist on \`${ownerTable.logicalName}\`.`,
+						DOCS.filterRows,
+					),
+				);
+			}
+		} else if (node.type === "lambda") {
+			const nav = ownerTable.navigationProperties.find((n) => n.name === node.nav);
+			if (!nav) {
+				errors.push(
+					iss(
+						`$filter lambda: nav \`${node.nav}\` does not exist on \`${ownerTable.logicalName}\`.`,
+						DOCS.filterRows,
+					),
+				);
+				continue;
+			}
+			const targetTbl = await loadTableWithTimeout(loadTable, nav.targetEntity);
+			if (!targetTbl) {
+				warnings.push(
+					iss(
+						`Metadata for \`${nav.targetEntity}\` (lambda target via \`${node.nav}\`) could not be loaded — inner filter not column-validated.`,
+					),
+				);
+				continue;
+			}
+			await validateFilterColumns(node.inner, targetTbl, loadTable, errors, warnings, node.alias);
+		}
+	}
 }
 
 async function validateExpandTree(
-  spec: ExpandSpec,
-  parentTbl: TableMeta,
-  loadTable: LoadTable,
-  errors: ParseIssue[],
-  warnings: ParseIssue[],
+	spec: ExpandSpec,
+	parentTbl: TableMeta,
+	loadTable: LoadTable,
+	errors: ParseIssue[],
+	warnings: ParseIssue[],
 ): Promise<void> {
-  const nav = parentTbl.navigationProperties.find(n => n.name === spec.nav);
-  if (!nav) {
-    errors.push(iss(
-      `$expand: navigation property \`${spec.nav}\` does not exist on \`${parentTbl.logicalName}\`.`,
-      DOCS.joinTables,
-    ));
-    return;
-  }
-  const targetTbl = await loadTableWithTimeout(loadTable, nav.targetEntity);
-  if (!targetTbl) {
-    warnings.push(iss(
-      `Metadata for \`${nav.targetEntity}\` (target of \`${spec.nav}\`) could not be loaded — inner $select not validated.`,
-    ));
-    return;
-  }
-  for (const c of spec.select) {
-    if (!columnExistsOnTable(targetTbl, c)) {
-      errors.push(iss(
-        `$expand=${spec.nav}: column \`${c}\` does not exist on \`${nav.targetEntity}\`.`,
-        DOCS.attrMetadata,
-      ));
-    }
-  }
-  for (const o of spec.orderby) {
-    if (!columnExistsOnTable(targetTbl, o.col)) {
-      errors.push(iss(
-        `$expand=${spec.nav}/$orderby: column \`${o.col}\` does not exist on \`${nav.targetEntity}\`.`,
-        DOCS.attrMetadata,
-      ));
-    }
-  }
-  if (spec.filter) {
-    await validateFilterColumns(spec.filter, targetTbl, loadTable, errors, warnings, undefined);
-  }
-  if (spec.nestedExpand) {
-    for (const ne of spec.nestedExpand) {
-      await validateExpandTree(ne, targetTbl, loadTable, errors, warnings);
-    }
-  }
+	const nav = parentTbl.navigationProperties.find((n) => n.name === spec.nav);
+	if (!nav) {
+		errors.push(
+			iss(
+				`$expand: navigation property \`${spec.nav}\` does not exist on \`${parentTbl.logicalName}\`.`,
+				DOCS.joinTables,
+			),
+		);
+		return;
+	}
+	const targetTbl = await loadTableWithTimeout(loadTable, nav.targetEntity);
+	if (!targetTbl) {
+		warnings.push(
+			iss(
+				`Metadata for \`${nav.targetEntity}\` (target of \`${spec.nav}\`) could not be loaded — inner $select not validated.`,
+			),
+		);
+		return;
+	}
+	for (const c of spec.select) {
+		if (!columnExistsOnTable(targetTbl, c)) {
+			errors.push(
+				iss(
+					`$expand=${spec.nav}: column \`${c}\` does not exist on \`${nav.targetEntity}\`.`,
+					DOCS.attrMetadata,
+				),
+			);
+		}
+	}
+	for (const o of spec.orderby) {
+		if (!columnExistsOnTable(targetTbl, o.col)) {
+			errors.push(
+				iss(
+					`$expand=${spec.nav}/$orderby: column \`${o.col}\` does not exist on \`${nav.targetEntity}\`.`,
+					DOCS.attrMetadata,
+				),
+			);
+		}
+	}
+	if (spec.filter) {
+		await validateFilterColumns(spec.filter, targetTbl, loadTable, errors, warnings, undefined);
+	}
+	if (spec.nestedExpand) {
+		for (const ne of spec.nestedExpand) {
+			await validateExpandTree(ne, targetTbl, loadTable, errors, warnings);
+		}
+	}
 }
 
 /**
@@ -511,33 +577,37 @@ async function validateExpandTree(
  * wire form for lookups).
  */
 function columnExistsOnTable(table: TableMeta, name: string): boolean {
-  return table.columns.some(c => c.logicalName === name || c.oDataName === name);
+	return table.columns.some((c) => c.logicalName === name || c.oDataName === name);
 }
 
 // ── URL splitting helpers ───────────────────────────────────────────────
 
 function splitUrl(rawUrl: string): { entitySet: string; query: string } {
-  let s = rawUrl.trim();
-  // Strip absolute prefix (https://<host>/api/data/vX.Y/) or any leading slash.
-  s = s.replace(/^https?:\/\/[^/]+/, '');
-  s = s.replace(/^\/?api\/data\/v\d+(\.\d+)?\//, '');
-  s = s.replace(/^\//, '');
-  // Decode percent-encoding — pasted URLs are often url-encoded.
-  // Decode once cautiously; some test runners log already-decoded URLs.
-  if (/%[0-9A-Fa-f]{2}/.test(s)) {
-    try { s = decodeURIComponent(s); } catch { /* keep original */ }
-  }
-  const qIdx = s.indexOf('?');
-  if (qIdx < 0) return { entitySet: stripKeyPart(s), query: '' };
-  const entitySet = stripKeyPart(s.slice(0, qIdx));
-  const query = s.slice(qIdx + 1);
-  return { entitySet, query };
+	let s = rawUrl.trim();
+	// Strip absolute prefix (https://<host>/api/data/vX.Y/) or any leading slash.
+	s = s.replace(/^https?:\/\/[^/]+/, "");
+	s = s.replace(/^\/?api\/data\/v\d+(\.\d+)?\//, "");
+	s = s.replace(/^\//, "");
+	// Decode percent-encoding — pasted URLs are often url-encoded.
+	// Decode once cautiously; some test runners log already-decoded URLs.
+	if (/%[0-9A-Fa-f]{2}/.test(s)) {
+		try {
+			s = decodeURIComponent(s);
+		} catch {
+			/* keep original */
+		}
+	}
+	const qIdx = s.indexOf("?");
+	if (qIdx < 0) return { entitySet: stripKeyPart(s), query: "" };
+	const entitySet = stripKeyPart(s.slice(0, qIdx));
+	const query = s.slice(qIdx + 1);
+	return { entitySet, query };
 }
 
 /** `accounts(<guid>)` → `accounts` — keys aren't relevant for retrieve-multiple. */
 function stripKeyPart(p: string): string {
-  const i = p.indexOf('(');
-  return i >= 0 ? p.slice(0, i) : p;
+	const i = p.indexOf("(");
+	return i >= 0 ? p.slice(0, i) : p;
 }
 
 /**
@@ -547,17 +617,17 @@ function stripKeyPart(p: string): string {
  * internally. We still scan for balanced parens to be safe.)
  */
 function splitQueryOptions(query: string): Record<string, string> {
-  if (!query) return {};
-  const out: Record<string, string> = {};
-  const parts = topLevelSplit(query, '&');
-  for (const part of parts) {
-    const eq = part.indexOf('=');
-    if (eq < 0) continue;
-    const k = part.slice(0, eq);
-    const v = part.slice(eq + 1);
-    out[k] = v;
-  }
-  return out;
+	if (!query) return {};
+	const out: Record<string, string> = {};
+	const parts = topLevelSplit(query, "&");
+	for (const part of parts) {
+		const eq = part.indexOf("=");
+		if (eq < 0) continue;
+		const k = part.slice(0, eq);
+		const v = part.slice(eq + 1);
+		out[k] = v;
+	}
+	return out;
 }
 
 /**
@@ -572,42 +642,69 @@ function splitQueryOptions(query: string): Record<string, string> {
  *   • $apply pipeline stages ('/' between filter/groupby/aggregate)
  */
 export function topLevelSplit(s: string, delim: string): string[] {
-  const out: string[] = [];
-  let depth = 0;
-  let bracketDepth = 0;
-  let inString = false;
-  let buf = '';
-  for (let i = 0; i < s.length; i++) {
-    const c = s[i];
-    if (inString) {
-      buf += c;
-      if (c === "'") {
-        if (s[i + 1] === "'") { buf += "'"; i++; continue; }
-        inString = false;
-      }
-      continue;
-    }
-    if (c === "'") { inString = true; buf += c; continue; }
-    if (c === '(') { depth++; buf += c; continue; }
-    if (c === ')') { depth--; buf += c; continue; }
-    if (c === '[') { bracketDepth++; buf += c; continue; }
-    if (c === ']') { bracketDepth--; buf += c; continue; }
-    if (c === delim && depth === 0 && bracketDepth === 0) {
-      out.push(buf);
-      buf = '';
-      continue;
-    }
-    buf += c;
-  }
-  if (buf.length) out.push(buf);
-  return out;
+	const out: string[] = [];
+	let depth = 0;
+	let bracketDepth = 0;
+	let inString = false;
+	let buf = "";
+	for (let i = 0; i < s.length; i++) {
+		const c = s[i];
+		if (inString) {
+			buf += c;
+			if (c === "'") {
+				if (s[i + 1] === "'") {
+					buf += "'";
+					i++;
+					continue;
+				}
+				inString = false;
+			}
+			continue;
+		}
+		if (c === "'") {
+			inString = true;
+			buf += c;
+			continue;
+		}
+		if (c === "(") {
+			depth++;
+			buf += c;
+			continue;
+		}
+		if (c === ")") {
+			depth--;
+			buf += c;
+			continue;
+		}
+		if (c === "[") {
+			bracketDepth++;
+			buf += c;
+			continue;
+		}
+		if (c === "]") {
+			bracketDepth--;
+			buf += c;
+			continue;
+		}
+		if (c === delim && depth === 0 && bracketDepth === 0) {
+			out.push(buf);
+			buf = "";
+			continue;
+		}
+		buf += c;
+	}
+	if (buf.length) out.push(buf);
+	return out;
 }
 
 // ── $select parser ──────────────────────────────────────────────────────
 
 function parseSelect(s: string, table?: TableMeta): string[] {
-  return s.split(',').map(c => c.trim()).filter(Boolean)
-    .map(col => decodeLookupValueForm(col, table));
+	return s
+		.split(",")
+		.map((c) => c.trim())
+		.filter(Boolean)
+		.map((col) => decodeLookupValueForm(col, table));
 }
 
 /**
@@ -636,35 +733,44 @@ function parseSelect(s: string, table?: TableMeta): string[] {
  *     The orphan banner explains what happened.
  */
 function decodeLookupValueForm(col: string, table?: TableMeta): string {
-  if (!col.startsWith('_') || !col.endsWith('_value') || col.length <= '_value'.length + 1) {
-    return col;
-  }
-  const bare = col.slice(1, -'_value'.length);
-  if (!table) return col; // No metadata available — preserve wire form (see comment above).
-  const meta = table.columns.find(c => c.logicalName === bare);
-  if (meta && (meta.attributeType === 'Lookup' || meta.attributeType === 'Customer' || meta.attributeType === 'Owner')) {
-    return bare;
-  }
-  // Column doesn't exist or isn't a lookup → preserve `_value` form so the
-  // round-trip is faithful. Encoder's `attrRefByName` falls through to the
-  // logicalName as-is when no matching column is found.
-  return col;
+	if (!col.startsWith("_") || !col.endsWith("_value") || col.length <= "_value".length + 1) {
+		return col;
+	}
+	const bare = col.slice(1, -"_value".length);
+	if (!table) return col; // No metadata available — preserve wire form (see comment above).
+	const meta = table.columns.find((c) => c.logicalName === bare);
+	if (
+		meta &&
+		(meta.attributeType === "Lookup" ||
+			meta.attributeType === "Customer" ||
+			meta.attributeType === "Owner")
+	) {
+		return bare;
+	}
+	// Column doesn't exist or isn't a lookup → preserve `_value` form so the
+	// round-trip is faithful. Encoder's `attrRefByName` falls through to the
+	// logicalName as-is when no matching column is found.
+	return col;
 }
 
 // ── $orderby parser ─────────────────────────────────────────────────────
 
 function parseOrderby(s: string, table?: TableMeta): OrderbySpec[] {
-  return s.split(',').map(c => c.trim()).filter(Boolean).map(seg => {
-    // `<col> asc|desc?`
-    const m = seg.match(/^(\S+)(?:\s+(asc|desc))?$/i);
-    const id = newId('ord');
-    if (!m) return { id, col: seg, dir: 'asc' as const };
-    return {
-      id,
-      col: decodeLookupValueForm(m[1], table),
-      dir: (m[2]?.toLowerCase() === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc',
-    };
-  });
+	return s
+		.split(",")
+		.map((c) => c.trim())
+		.filter(Boolean)
+		.map((seg) => {
+			// `<col> asc|desc?`
+			const m = seg.match(/^(\S+)(?:\s+(asc|desc))?$/i);
+			const id = newId("ord");
+			if (!m) return { id, col: seg, dir: "asc" as const };
+			return {
+				id,
+				col: decodeLookupValueForm(m[1], table),
+				dir: (m[2]?.toLowerCase() === "desc" ? "desc" : "asc") as "asc" | "desc",
+			};
+		});
 }
 
 // ── $filter parser ──────────────────────────────────────────────────────
@@ -672,188 +778,223 @@ function parseOrderby(s: string, table?: TableMeta): OrderbySpec[] {
 // Tokenize → recursive descent → FilterGroup tree.
 
 interface Tok {
-  kind: 'ident' | 'string' | 'number' | 'lparen' | 'rparen' | 'comma' | 'colon' | 'bracket';
-  value: string;
+	kind: "ident" | "string" | "number" | "lparen" | "rparen" | "comma" | "colon" | "bracket";
+	value: string;
 }
 
 function tokenize(input: string): Tok[] {
-  const out: Tok[] = [];
-  let i = 0;
-  while (i < input.length) {
-    const c = input[i];
-    if (c === ' ' || c === '\t' || c === '\n' || c === '\r') { i++; continue; }
-    if (c === '(') { out.push({ kind: 'lparen', value: '(' }); i++; continue; }
-    if (c === ')') { out.push({ kind: 'rparen', value: ')' }); i++; continue; }
-    if (c === ',') { out.push({ kind: 'comma', value: ',' }); i++; continue; }
-    if (c === ':') {
-      // A standalone colon means either:
-      //   • lambda alias separator: `any(c: <expr>)` — `:` here is NOT
-      //     followed by a digit, so emit the colon token.
-      //   • inside an ISO datetime literal: `2024-01-01T00:00:00Z` — the
-      //     `:` is between digits. The previous ident accumulator already
-      //     handles this case (we never enter the dispatch loop mid-ident),
-      //     but if a value starts with `:` followed by a digit, fall through
-      //     to treat the whole run as one ident token. Belt-and-suspenders.
-      const next = input[i + 1];
-      if (next && /\d/.test(next)) {
-        // Fall through to the ident accumulator.
-      } else {
-        out.push({ kind: 'colon', value: ':' }); i++; continue;
-      }
-    }
-    if (c === "'") {
-      // OData string literal — '' is an escaped single quote.
-      let s = ''; i++;
-      while (i < input.length) {
-        if (input[i] === "'" && input[i + 1] === "'") { s += "'"; i += 2; continue; }
-        if (input[i] === "'") { i++; break; }
-        s += input[i++];
-      }
-      out.push({ kind: 'string', value: s });
-      continue;
-    }
-    if (c === '[') {
-      // PropertyValues=[...] — capture verbatim, JSON-decode at use site.
-      let depth = 0; let s = '';
-      while (i < input.length) {
-        const ch = input[i];
-        s += ch;
-        if (ch === '[') depth++;
-        else if (ch === ']') { depth--; if (depth === 0) { i++; break; } }
-        i++;
-      }
-      out.push({ kind: 'bracket', value: s });
-      continue;
-    }
-    // Identifier (possibly dotted/slashed/dashed/dot-namespaced):
-    //   primarycontactid          col
-    //   c/firstname               lambda-scoped col
-    //   primarycontactid/fullname nav-path col
-    //   Microsoft.Dynamics.CRM.X  DV fn ident
-    //   true / false / null       literals (treated as idents)
-    //   2024-01-01T00:00:00Z      datetime literal (treated as ident)
-    //   2024-01-01T00:00:00+05:30 datetime with offset
-    //   3.14, -42                 numbers (treated as idents until we type-check)
-    //
-    // The `:` character is special. It can mean:
-    //   (a) lambda alias separator `c: <expr>` — `:` is followed by a
-    //       letter or whitespace.
-    //   (b) part of an ISO datetime — `:` is followed by a digit
-    //       (`T00:00:00` is part of `2024-01-01T00:00:00Z`).
-    // We include `:` in the ident ONLY when the next character is a digit.
-    // Same rule for the offset-introducer `+` / `-` after a `:dd` pair —
-    // but those are already non-break chars, so they handle themselves.
-    let s = '';
-    while (i < input.length) {
-      const ch = input[i];
-      if (' \t\n\r(),[\''.includes(ch)) break;
-      if (ch === ':') {
-        const next = input[i + 1];
-        if (!next || !/\d/.test(next)) break;
-      }
-      s += ch;
-      i++;
-    }
-    if (!s) { i++; continue; }
-    // Classify number vs ident — pure number/decimal/scientific.
-    if (/^-?\d[\d.eE+\-]*$/.test(s)) {
-      out.push({ kind: 'number', value: s });
-    } else {
-      out.push({ kind: 'ident', value: s });
-    }
-  }
-  return out;
+	const out: Tok[] = [];
+	let i = 0;
+	while (i < input.length) {
+		const c = input[i];
+		if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+			i++;
+			continue;
+		}
+		if (c === "(") {
+			out.push({ kind: "lparen", value: "(" });
+			i++;
+			continue;
+		}
+		if (c === ")") {
+			out.push({ kind: "rparen", value: ")" });
+			i++;
+			continue;
+		}
+		if (c === ",") {
+			out.push({ kind: "comma", value: "," });
+			i++;
+			continue;
+		}
+		if (c === ":") {
+			// A standalone colon means either:
+			//   • lambda alias separator: `any(c: <expr>)` — `:` here is NOT
+			//     followed by a digit, so emit the colon token.
+			//   • inside an ISO datetime literal: `2024-01-01T00:00:00Z` — the
+			//     `:` is between digits. The previous ident accumulator already
+			//     handles this case (we never enter the dispatch loop mid-ident),
+			//     but if a value starts with `:` followed by a digit, fall through
+			//     to treat the whole run as one ident token. Belt-and-suspenders.
+			const next = input[i + 1];
+			if (next && /\d/.test(next)) {
+				// Fall through to the ident accumulator.
+			} else {
+				out.push({ kind: "colon", value: ":" });
+				i++;
+				continue;
+			}
+		}
+		if (c === "'") {
+			// OData string literal — '' is an escaped single quote.
+			let s = "";
+			i++;
+			while (i < input.length) {
+				if (input[i] === "'" && input[i + 1] === "'") {
+					s += "'";
+					i += 2;
+					continue;
+				}
+				if (input[i] === "'") {
+					i++;
+					break;
+				}
+				s += input[i++];
+			}
+			out.push({ kind: "string", value: s });
+			continue;
+		}
+		if (c === "[") {
+			// PropertyValues=[...] — capture verbatim, JSON-decode at use site.
+			let depth = 0;
+			let s = "";
+			while (i < input.length) {
+				const ch = input[i];
+				s += ch;
+				if (ch === "[") depth++;
+				else if (ch === "]") {
+					depth--;
+					if (depth === 0) {
+						i++;
+						break;
+					}
+				}
+				i++;
+			}
+			out.push({ kind: "bracket", value: s });
+			continue;
+		}
+		// Identifier (possibly dotted/slashed/dashed/dot-namespaced):
+		//   primarycontactid          col
+		//   c/firstname               lambda-scoped col
+		//   primarycontactid/fullname nav-path col
+		//   Microsoft.Dynamics.CRM.X  DV fn ident
+		//   true / false / null       literals (treated as idents)
+		//   2024-01-01T00:00:00Z      datetime literal (treated as ident)
+		//   2024-01-01T00:00:00+05:30 datetime with offset
+		//   3.14, -42                 numbers (treated as idents until we type-check)
+		//
+		// The `:` character is special. It can mean:
+		//   (a) lambda alias separator `c: <expr>` — `:` is followed by a
+		//       letter or whitespace.
+		//   (b) part of an ISO datetime — `:` is followed by a digit
+		//       (`T00:00:00` is part of `2024-01-01T00:00:00Z`).
+		// We include `:` in the ident ONLY when the next character is a digit.
+		// Same rule for the offset-introducer `+` / `-` after a `:dd` pair —
+		// but those are already non-break chars, so they handle themselves.
+		let s = "";
+		while (i < input.length) {
+			const ch = input[i];
+			if (" \t\n\r(),['".includes(ch)) break;
+			if (ch === ":") {
+				const next = input[i + 1];
+				if (!next || !/\d/.test(next)) break;
+			}
+			s += ch;
+			i++;
+		}
+		if (!s) {
+			i++;
+			continue;
+		}
+		// Classify number vs ident — pure number/decimal/scientific.
+		if (/^-?\d[\d.eE+\-]*$/.test(s)) {
+			out.push({ kind: "number", value: s });
+		} else {
+			out.push({ kind: "ident", value: s });
+		}
+	}
+	return out;
 }
 
 interface ParseFilterCtx {
-  toks: Tok[];
-  pos: number;
-  warnings: ParseIssue[];
-  errors: ParseIssue[];
-  /** Alias of the enclosing lambda, if we're recursing inside one. */
-  outerAlias?: string;
+	toks: Tok[];
+	pos: number;
+	warnings: ParseIssue[];
+	errors: ParseIssue[];
+	/** Alias of the enclosing lambda, if we're recursing inside one. */
+	outerAlias?: string;
 }
 
-const COMPARISON_OPS = new Set(['eq', 'ne', 'gt', 'ge', 'lt', 'le']);
-const STRING_FN_NAMES = new Set(['contains', 'startswith', 'endswith']);
-const BOOL_LITERALS = new Set(['true', 'false']);
+const COMPARISON_OPS = new Set(["eq", "ne", "gt", "ge", "lt", "le"]);
+const STRING_FN_NAMES = new Set(["contains", "startswith", "endswith"]);
+const BOOL_LITERALS = new Set(["true", "false"]);
 
 function emptyFilterGroup(): FilterGroup {
-  return { id: newId('root'), type: 'group', combinator: 'and', rules: [] };
+	return { id: newId("root"), type: "group", combinator: "and", rules: [] };
 }
 
-function parseFilter(input: string, _table: TableMeta | undefined): { group: FilterGroup; warnings: ParseIssue[]; errors: ParseIssue[] } {
-  const warnings: ParseIssue[] = [];
-  const errors: ParseIssue[] = [];
-  const ctx: ParseFilterCtx = { toks: tokenize(input), pos: 0, warnings, errors };
-  if (ctx.toks.length === 0) return { group: emptyFilterGroup(), warnings, errors };
-  try {
-    const node = parseOrExpr(ctx);
-    // Wrap a single-node result in a root group so the FilterEditor sees a
-    // proper tree.
-    const group: FilterGroup = node.type === 'group'
-      ? node
-      : { id: newId('root'), type: 'group', combinator: 'and', rules: [node] };
-    return { group, warnings, errors };
-  } catch (e) {
-    // Convert thrown ParseFailure (or generic Error) into an entry in errors
-    // rather than propagating up — gives the user every detected issue at
-    // once instead of bailing at the first one.
-    if (e instanceof ParseFailure) {
-      errors.push(iss(e.message, e.learnMoreUrl));
-    } else {
-      errors.push(iss(e instanceof Error ? e.message : String(e), DOCS.filterRows));
-    }
-    return { group: emptyFilterGroup(), warnings, errors };
-  }
+function parseFilter(
+	input: string,
+	_table: TableMeta | undefined,
+): { group: FilterGroup; warnings: ParseIssue[]; errors: ParseIssue[] } {
+	const warnings: ParseIssue[] = [];
+	const errors: ParseIssue[] = [];
+	const ctx: ParseFilterCtx = { toks: tokenize(input), pos: 0, warnings, errors };
+	if (ctx.toks.length === 0) return { group: emptyFilterGroup(), warnings, errors };
+	try {
+		const node = parseOrExpr(ctx);
+		// Wrap a single-node result in a root group so the FilterEditor sees a
+		// proper tree.
+		const group: FilterGroup =
+			node.type === "group"
+				? node
+				: { id: newId("root"), type: "group", combinator: "and", rules: [node] };
+		return { group, warnings, errors };
+	} catch (e) {
+		// Convert thrown ParseFailure (or generic Error) into an entry in errors
+		// rather than propagating up — gives the user every detected issue at
+		// once instead of bailing at the first one.
+		if (e instanceof ParseFailure) {
+			errors.push(iss(e.message, e.learnMoreUrl));
+		} else {
+			errors.push(iss(e instanceof Error ? e.message : String(e), DOCS.filterRows));
+		}
+		return { group: emptyFilterGroup(), warnings, errors };
+	}
 }
 
 /** orExpr := andExpr ('or' andExpr)* */
 function parseOrExpr(ctx: ParseFilterCtx): FilterNode {
-  const left = parseAndExpr(ctx);
-  if (!isKeywordAhead(ctx, 'or')) return left;
-  const children: FilterNode[] = [left];
-  while (isKeywordAhead(ctx, 'or')) {
-    consumeKeyword(ctx, 'or');
-    children.push(parseAndExpr(ctx));
-  }
-  return {
-    id: newId('g'),
-    type: 'group',
-    combinator: 'or',
-    rules: children.flatMap(c =>
-      (c.type === 'group' && c.combinator === 'or') ? c.rules : [c],
-    ),
-  };
+	const left = parseAndExpr(ctx);
+	if (!isKeywordAhead(ctx, "or")) return left;
+	const children: FilterNode[] = [left];
+	while (isKeywordAhead(ctx, "or")) {
+		consumeKeyword(ctx, "or");
+		children.push(parseAndExpr(ctx));
+	}
+	return {
+		id: newId("g"),
+		type: "group",
+		combinator: "or",
+		rules: children.flatMap((c) => (c.type === "group" && c.combinator === "or" ? c.rules : [c])),
+	};
 }
 
 /** andExpr := unaryExpr ('and' unaryExpr)* */
 function parseAndExpr(ctx: ParseFilterCtx): FilterNode {
-  const left = parseUnaryExpr(ctx);
-  if (!isKeywordAhead(ctx, 'and')) return left;
-  const children: FilterNode[] = [left];
-  while (isKeywordAhead(ctx, 'and')) {
-    consumeKeyword(ctx, 'and');
-    children.push(parseUnaryExpr(ctx));
-  }
-  return {
-    id: newId('g'),
-    type: 'group',
-    combinator: 'and',
-    rules: children.flatMap(c =>
-      (c.type === 'group' && c.combinator === 'and') ? c.rules : [c],
-    ),
-  };
+	const left = parseUnaryExpr(ctx);
+	if (!isKeywordAhead(ctx, "and")) return left;
+	const children: FilterNode[] = [left];
+	while (isKeywordAhead(ctx, "and")) {
+		consumeKeyword(ctx, "and");
+		children.push(parseUnaryExpr(ctx));
+	}
+	return {
+		id: newId("g"),
+		type: "group",
+		combinator: "and",
+		rules: children.flatMap((c) => (c.type === "group" && c.combinator === "and" ? c.rules : [c])),
+	};
 }
 
 /** unaryExpr := 'not' unaryExpr | primary */
 function parseUnaryExpr(ctx: ParseFilterCtx): FilterNode {
-  if (isKeywordAhead(ctx, 'not')) {
-    consumeKeyword(ctx, 'not');
-    const inner = parseUnaryExpr(ctx);
-    return applyNot(inner, ctx);
-  }
-  return parsePrimary(ctx);
+	if (isKeywordAhead(ctx, "not")) {
+		consumeKeyword(ctx, "not");
+		const inner = parseUnaryExpr(ctx);
+		return applyNot(inner, ctx);
+	}
+	return parsePrimary(ctx);
 }
 
 /**
@@ -872,592 +1013,677 @@ function parseUnaryExpr(ctx: ParseFilterCtx): FilterNode {
  *     explicit `Not*` sibling fn instead.
  */
 function applyNot(node: FilterNode, ctx: ParseFilterCtx): FilterNode {
-  if (node.type === 'rule') {
-    const op = findOperator(node.op);
-    if (op && op.kind === 'odata-fn') {
-      return { ...node, negated: true };
-    }
-    // Wrap the comparison in a `not (…)` group of one — encoder emits
-    // exactly `not (<col> <op> <val>)` which Dataverse accepts.
-    return {
-      id: newId('g'),
-      type: 'group',
-      combinator: 'and',
-      rules: [node],
-      negated: true,
-    };
-  }
-  if (node.type === 'group') {
-    // Stacking `not` flips it back off rather than double-wrapping.
-    return { ...node, negated: !node.negated };
-  }
-  if (node.type === 'lambda') {
-    return { ...node, negated: !node.negated };
-  }
-  if (node.type === 'function') {
-    ctx.warnings.push(iss(
-      `\`not Microsoft.Dynamics.CRM.${node.op}(…)\` is rejected by Dataverse — dropped the \`not\`, function preserved. Use the explicit \`Not*\` sibling instead.`,
-      DOCS.queryFunctions,
-    ));
-    return node;
-  }
-  return node;
+	if (node.type === "rule") {
+		const op = findOperator(node.op);
+		if (op && op.kind === "odata-fn") {
+			return { ...node, negated: true };
+		}
+		// Wrap the comparison in a `not (…)` group of one — encoder emits
+		// exactly `not (<col> <op> <val>)` which Dataverse accepts.
+		return {
+			id: newId("g"),
+			type: "group",
+			combinator: "and",
+			rules: [node],
+			negated: true,
+		};
+	}
+	if (node.type === "group") {
+		// Stacking `not` flips it back off rather than double-wrapping.
+		return { ...node, negated: !node.negated };
+	}
+	if (node.type === "lambda") {
+		return { ...node, negated: !node.negated };
+	}
+	if (node.type === "function") {
+		ctx.warnings.push(
+			iss(
+				`\`not Microsoft.Dynamics.CRM.${node.op}(…)\` is rejected by Dataverse — dropped the \`not\`, function preserved. Use the explicit \`Not*\` sibling instead.`,
+				DOCS.queryFunctions,
+			),
+		);
+		return node;
+	}
+	return node;
 }
 
 /** primary := '(' expr ')' | dvFn | strFn | lambda | comparison */
 function parsePrimary(ctx: ParseFilterCtx): FilterNode {
-  const t = ctx.toks[ctx.pos];
-  if (!t) throw new Error('Unexpected end of $filter input.');
+	const t = ctx.toks[ctx.pos];
+	if (!t) throw new Error("Unexpected end of $filter input.");
 
-  // Grouped sub-expression
-  if (t.kind === 'lparen') {
-    ctx.pos++;
-    const inner = parseOrExpr(ctx);
-    expect(ctx, 'rparen');
-    return inner;
-  }
+	// Grouped sub-expression
+	if (t.kind === "lparen") {
+		ctx.pos++;
+		const inner = parseOrExpr(ctx);
+		expect(ctx, "rparen");
+		return inner;
+	}
 
-  // Identifier — could be a Dataverse fn call, a string fn, a path leading to
-  // a lambda, or the LHS of a comparison.
-  if (t.kind === 'ident') {
-    const ident = t.value;
+	// Identifier — could be a Dataverse fn call, a string fn, a path leading to
+	// a lambda, or the LHS of a comparison.
+	if (t.kind === "ident") {
+		const ident = t.value;
 
-    // ── Dataverse fn: Microsoft.Dynamics.CRM.X( ... )
-    if (ident.startsWith('Microsoft.Dynamics.CRM.')) {
-      // Must be followed by `(`.
-      const next = ctx.toks[ctx.pos + 1];
-      if (next?.kind === 'lparen') {
-        return parseDvFunction(ctx, ident);
-      }
-    }
+		// ── Dataverse fn: Microsoft.Dynamics.CRM.X( ... )
+		if (ident.startsWith("Microsoft.Dynamics.CRM.")) {
+			// Must be followed by `(`.
+			const next = ctx.toks[ctx.pos + 1];
+			if (next?.kind === "lparen") {
+				return parseDvFunction(ctx, ident);
+			}
+		}
 
-    // ── OData string fn: contains/startswith/endswith ( col, lit )
-    if (STRING_FN_NAMES.has(ident)) {
-      const next = ctx.toks[ctx.pos + 1];
-      if (next?.kind === 'lparen') {
-        return parseStringFunction(ctx, ident);
-      }
-    }
+		// ── OData string fn: contains/startswith/endswith ( col, lit )
+		if (STRING_FN_NAMES.has(ident)) {
+			const next = ctx.toks[ctx.pos + 1];
+			if (next?.kind === "lparen") {
+				return parseStringFunction(ctx, ident);
+			}
+		}
 
-    // ── Lambda: <path>/any( [alias: inner] ) | <path>/all( ... )
-    // The path may end in '/any' or '/all' — split and check.
-    const lambdaMatch = ident.match(/^(.+?)\/(any|all)$/);
-    if (lambdaMatch) {
-      const next = ctx.toks[ctx.pos + 1];
-      if (next?.kind === 'lparen') {
-        return parseLambda(ctx, lambdaMatch[1], lambdaMatch[2] as 'any' | 'all');
-      }
-    }
+		// ── Lambda: <path>/any( [alias: inner] ) | <path>/all( ... )
+		// The path may end in '/any' or '/all' — split and check.
+		const lambdaMatch = ident.match(/^(.+?)\/(any|all)$/);
+		if (lambdaMatch) {
+			const next = ctx.toks[ctx.pos + 1];
+			if (next?.kind === "lparen") {
+				return parseLambda(ctx, lambdaMatch[1], lambdaMatch[2] as "any" | "all");
+			}
+		}
 
-    // ── Unknown function call — ident followed by `(` that didn't match
-    //    any of the function shapes above. Typo'd Dataverse function name
-    //    (missing namespace prefix), or made-up function. The user
-    //    probably meant a real function but mis-spelled it. Throwing
-    //    gives a clearer error than letting parseComparison choke on
-    //    the unexpected `(` token.
-    const next = ctx.toks[ctx.pos + 1];
-    if (next?.kind === 'lparen') {
-      throw new ParseFailure(
-        `Unknown function \`${ident}(…)\` in $filter. Dataverse query functions must be prefixed with \`Microsoft.Dynamics.CRM.\` (e.g. \`Microsoft.Dynamics.CRM.${ident}(…)\`); OData string functions are \`contains\`/\`startswith\`/\`endswith\` only.`,
-        DOCS.queryFunctions,
-      );
-    }
+		// ── Unknown function call — ident followed by `(` that didn't match
+		//    any of the function shapes above. Typo'd Dataverse function name
+		//    (missing namespace prefix), or made-up function. The user
+		//    probably meant a real function but mis-spelled it. Throwing
+		//    gives a clearer error than letting parseComparison choke on
+		//    the unexpected `(` token.
+		const next = ctx.toks[ctx.pos + 1];
+		if (next?.kind === "lparen") {
+			throw new ParseFailure(
+				`Unknown function \`${ident}(…)\` in $filter. Dataverse query functions must be prefixed with \`Microsoft.Dynamics.CRM.\` (e.g. \`Microsoft.Dynamics.CRM.${ident}(…)\`); OData string functions are \`contains\`/\`startswith\`/\`endswith\` only.`,
+				DOCS.queryFunctions,
+			);
+		}
 
-    // ── Comparison (eq/ne/…) — LHS is the ident; consume and continue.
-    return parseComparison(ctx);
-  }
+		// ── Comparison (eq/ne/…) — LHS is the ident; consume and continue.
+		return parseComparison(ctx);
+	}
 
-  // String / number / bracket at this position is unexpected — treat as
-  // best-effort recovery: produce a stub rule.
-  throw new Error(`Unexpected token \`${t.value}\` at position ${ctx.pos} in $filter.`);
+	// String / number / bracket at this position is unexpected — treat as
+	// best-effort recovery: produce a stub rule.
+	throw new Error(`Unexpected token \`${t.value}\` at position ${ctx.pos} in $filter.`);
 }
 
 function parseComparison(ctx: ParseFilterCtx): FilterRule {
-  const lhsTok = ctx.toks[ctx.pos++];
-  if (lhsTok.kind !== 'ident') {
-    throw new Error(`Comparison LHS must be a column reference, got \`${lhsTok.value}\`.`);
-  }
-  let col = lhsTok.value;
-  // Decode wire-form lookup column to bare logical name. Preserve any
-  // lambda-alias prefix or nav-path prefix.
-  col = rewriteLookupValueInPath(col);
+	const lhsTok = ctx.toks[ctx.pos++];
+	if (lhsTok.kind !== "ident") {
+		throw new Error(`Comparison LHS must be a column reference, got \`${lhsTok.value}\`.`);
+	}
+	let col = lhsTok.value;
+	// Decode wire-form lookup column to bare logical name. Preserve any
+	// lambda-alias prefix or nav-path prefix.
+	col = rewriteLookupValueInPath(col);
 
-  const opTok = ctx.toks[ctx.pos++];
-  if (!opTok || opTok.kind !== 'ident' || !COMPARISON_OPS.has(opTok.value.toLowerCase())) {
-    throw new Error(`Expected comparison operator after \`${col}\`, got \`${opTok?.value}\`.`);
-  }
-  const op = opTok.value.toLowerCase();
+	const opTok = ctx.toks[ctx.pos++];
+	if (!opTok || opTok.kind !== "ident" || !COMPARISON_OPS.has(opTok.value.toLowerCase())) {
+		throw new Error(`Expected comparison operator after \`${col}\`, got \`${opTok?.value}\`.`);
+	}
+	const op = opTok.value.toLowerCase();
 
-  // Check for `eq null` / `ne null`
-  const peek = ctx.toks[ctx.pos];
-  if (peek?.kind === 'ident' && peek.value.toLowerCase() === 'null') {
-    ctx.pos++;
-    const nullOp = op === 'eq' ? 'is-null' : op === 'ne' ? 'is-not-null' : null;
-    if (!nullOp) {
-      ctx.warnings.push(iss(
-        `\`${op} null\` is unusual — DRS will store as a literal value comparison.`,
-        DOCS.filterRows,
-      ));
-    } else {
-      return { id: newId('r'), type: 'rule', col, op: nullOp, val: '' };
-    }
-  }
+	// Check for `eq null` / `ne null`
+	const peek = ctx.toks[ctx.pos];
+	if (peek?.kind === "ident" && peek.value.toLowerCase() === "null") {
+		ctx.pos++;
+		const nullOp = op === "eq" ? "is-null" : op === "ne" ? "is-not-null" : null;
+		if (!nullOp) {
+			ctx.warnings.push(
+				iss(
+					`\`${op} null\` is unusual — DRS will store as a literal value comparison.`,
+					DOCS.filterRows,
+				),
+			);
+		} else {
+			return { id: newId("r"), type: "rule", col, op: nullOp, val: "" };
+		}
+	}
 
-  const rhs = ctx.toks[ctx.pos++];
-  if (!rhs) throw new Error(`Comparison \`${col} ${op}\` is missing its RHS.`);
+	const rhs = ctx.toks[ctx.pos++];
+	if (!rhs) throw new Error(`Comparison \`${col} ${op}\` is missing its RHS.`);
 
-  // RHS classification:
-  //   string literal       → valKind: literal, val = string
-  //   number               → valKind: literal, val = number-as-string
-  //   ident (true/false)   → valKind: literal, val = 'true'|'false'
-  //   ident (path)         → valKind: column (same-table col-vs-col)
-  //   ident (datetime)     → valKind: literal, val = ident
-  //   ident (guid)         → valKind: literal, val = ident
-  if (rhs.kind === 'string') {
-    return { id: newId('r'), type: 'rule', col, op, val: rhs.value, valKind: 'literal' };
-  }
-  if (rhs.kind === 'number') {
-    return { id: newId('r'), type: 'rule', col, op, val: rhs.value, valKind: 'literal' };
-  }
-  if (rhs.kind === 'ident') {
-    const v = rhs.value;
-    if (BOOL_LITERALS.has(v.toLowerCase())) {
-      return { id: newId('r'), type: 'rule', col, op, val: v.toLowerCase(), valKind: 'literal' };
-    }
-    // GUID / date / numeric-looking ident → literal.
-    if (looksLikeGuid(v) || looksLikeIsoDate(v)) {
-      return { id: newId('r'), type: 'rule', col, op, val: v, valKind: 'literal' };
-    }
-    // Otherwise: column-vs-column comparison. Decode wire form on RHS too.
-    return { id: newId('r'), type: 'rule', col, op, val: rewriteLookupValueInPath(v), valKind: 'column' };
-  }
-  throw new Error(`Unexpected RHS token \`${rhs.value}\` for \`${col} ${op}\`.`);
+	// RHS classification:
+	//   string literal       → valKind: literal, val = string
+	//   number               → valKind: literal, val = number-as-string
+	//   ident (true/false)   → valKind: literal, val = 'true'|'false'
+	//   ident (path)         → valKind: column (same-table col-vs-col)
+	//   ident (datetime)     → valKind: literal, val = ident
+	//   ident (guid)         → valKind: literal, val = ident
+	if (rhs.kind === "string") {
+		return { id: newId("r"), type: "rule", col, op, val: rhs.value, valKind: "literal" };
+	}
+	if (rhs.kind === "number") {
+		return { id: newId("r"), type: "rule", col, op, val: rhs.value, valKind: "literal" };
+	}
+	if (rhs.kind === "ident") {
+		const v = rhs.value;
+		if (BOOL_LITERALS.has(v.toLowerCase())) {
+			return { id: newId("r"), type: "rule", col, op, val: v.toLowerCase(), valKind: "literal" };
+		}
+		// GUID / date / numeric-looking ident → literal.
+		if (looksLikeGuid(v) || looksLikeIsoDate(v)) {
+			return { id: newId("r"), type: "rule", col, op, val: v, valKind: "literal" };
+		}
+		// Otherwise: column-vs-column comparison. Decode wire form on RHS too.
+		return {
+			id: newId("r"),
+			type: "rule",
+			col,
+			op,
+			val: rewriteLookupValueInPath(v),
+			valKind: "column",
+		};
+	}
+	throw new Error(`Unexpected RHS token \`${rhs.value}\` for \`${col} ${op}\`.`);
 }
 
 function parseStringFunction(ctx: ParseFilterCtx, name: string): FilterRule {
-  // Already at ident; consume ident + '(' + col + ',' + lit + ')'.
-  ctx.pos++; // consume ident
-  expect(ctx, 'lparen');
-  const colTok = ctx.toks[ctx.pos++];
-  if (colTok.kind !== 'ident') throw new Error(`${name}( … ) expected a column reference first.`);
-  expect(ctx, 'comma');
-  const litTok = ctx.toks[ctx.pos++];
-  if (litTok.kind !== 'string') throw new Error(`${name}(${colTok.value}, '…') expected a string literal as the second argument.`);
-  expect(ctx, 'rparen');
-  return {
-    id: newId('r'),
-    type: 'rule',
-    col: rewriteLookupValueInPath(colTok.value),
-    op: name,
-    val: litTok.value,
-    valKind: 'literal',
-  };
+	// Already at ident; consume ident + '(' + col + ',' + lit + ')'.
+	ctx.pos++; // consume ident
+	expect(ctx, "lparen");
+	const colTok = ctx.toks[ctx.pos++];
+	if (colTok.kind !== "ident") throw new Error(`${name}( … ) expected a column reference first.`);
+	expect(ctx, "comma");
+	const litTok = ctx.toks[ctx.pos++];
+	if (litTok.kind !== "string")
+		throw new Error(
+			`${name}(${colTok.value}, '…') expected a string literal as the second argument.`,
+		);
+	expect(ctx, "rparen");
+	return {
+		id: newId("r"),
+		type: "rule",
+		col: rewriteLookupValueInPath(colTok.value),
+		op: name,
+		val: litTok.value,
+		valKind: "literal",
+	};
 }
 
 function parseDvFunction(ctx: ParseFilterCtx, fullName: string): FilterFunctionNode {
-  // fullName is like 'Microsoft.Dynamics.CRM.LastXDays'. Strip prefix.
-  const shortName = fullName.replace(/^Microsoft\.Dynamics\.CRM\./, '');
-  const opDef = OPERATORS.find(o => o.id === shortName);
-  ctx.pos++; // consume the ident
-  expect(ctx, 'lparen');
+	// fullName is like 'Microsoft.Dynamics.CRM.LastXDays'. Strip prefix.
+	const shortName = fullName.replace(/^Microsoft\.Dynamics\.CRM\./, "");
+	const opDef = OPERATORS.find((o) => o.id === shortName);
+	ctx.pos++; // consume the ident
+	expect(ctx, "lparen");
 
-  // Parse named arguments — `PropertyName='col', PropertyValue=…, PropertyValues=[...]`.
-  const args = parseDvFnArgs(ctx);
-  expect(ctx, 'rparen');
+	// Parse named arguments — `PropertyName='col', PropertyValue=…, PropertyValues=[...]`.
+	const args = parseDvFnArgs(ctx);
+	expect(ctx, "rparen");
 
-  if (!opDef) {
-    // Hard reject: an unknown `Microsoft.Dynamics.CRM.<X>` function is
-    // either a typo or something not modeled in DRS. Dataverse will
-    // reject too — applying it to the builder would just be a broken
-    // chip the user can't fix.
-    ctx.errors.push(iss(
-      `Unknown Dataverse query function \`Microsoft.Dynamics.CRM.${shortName}\` — not in the documented set.`,
-      DOCS.queryFunctions,
-    ));
-  }
+	if (!opDef) {
+		// Hard reject: an unknown `Microsoft.Dynamics.CRM.<X>` function is
+		// either a typo or something not modeled in DRS. Dataverse will
+		// reject too — applying it to the builder would just be a broken
+		// chip the user can't fix.
+		ctx.errors.push(
+			iss(
+				`Unknown Dataverse query function \`Microsoft.Dynamics.CRM.${shortName}\` — not in the documented set.`,
+				DOCS.queryFunctions,
+			),
+		);
+	}
 
-  // Build the FilterFunctionNode. The encoder will strip alias prefixes / map
-  // hierarchy fn to PK — we store what the user wrote.
-  const node: FilterFunctionNode = {
-    id: newId('f'),
-    type: 'function',
-    op: shortName,
-    col: rewriteLookupValueInPath(args.PropertyName ?? ''),
-  };
-  if (args.PropertyValue != null) node.val = args.PropertyValue;
-  if (args.PropertyValue1 != null && args.PropertyValue2 != null) {
-    node.vals = [args.PropertyValue1, args.PropertyValue2];
-  }
-  if (args.PropertyValues) node.values = args.PropertyValues;
-  return node;
+	// Build the FilterFunctionNode. The encoder will strip alias prefixes / map
+	// hierarchy fn to PK — we store what the user wrote.
+	const node: FilterFunctionNode = {
+		id: newId("f"),
+		type: "function",
+		op: shortName,
+		col: rewriteLookupValueInPath(args.PropertyName ?? ""),
+	};
+	if (args.PropertyValue != null) node.val = args.PropertyValue;
+	if (args.PropertyValue1 != null && args.PropertyValue2 != null) {
+		node.vals = [args.PropertyValue1, args.PropertyValue2];
+	}
+	if (args.PropertyValues) node.values = args.PropertyValues;
+	return node;
 }
 
 interface DvFnArgs {
-  PropertyName?: string;
-  PropertyValue?: string;
-  PropertyValue1?: string;
-  PropertyValue2?: string;
-  PropertyValues?: string[];
+	PropertyName?: string;
+	PropertyValue?: string;
+	PropertyValue1?: string;
+	PropertyValue2?: string;
+	PropertyValues?: string[];
 }
 
 function parseDvFnArgs(ctx: ParseFilterCtx): DvFnArgs {
-  const out: DvFnArgs = {};
-  // Each arg: `Name=Value` or `Name='Value'` or `Name=[...]`. Separated by `,`.
-  // Use the comma-after-(close-paren-of-depth-0) logic since values can be
-  // bracket arrays which the tokenizer already groups.
-  while (ctx.toks[ctx.pos] && ctx.toks[ctx.pos].kind !== 'rparen') {
-    const nameTok = ctx.toks[ctx.pos++];
-    if (nameTok.kind !== 'ident') throw new Error(`Expected argument name, got \`${nameTok.value}\`.`);
-    // The argument name might come WITH `=Value` glued on as one token, since
-    // the tokenizer doesn't split on `=`. Handle both shapes.
-    let name = nameTok.value;
-    let valueRaw: string | undefined;
-    const eqIdx = name.indexOf('=');
-    if (eqIdx >= 0) {
-      valueRaw = name.slice(eqIdx + 1);
-      name = name.slice(0, eqIdx);
-    } else {
-      // The `=` is in the next token's prefix — but the tokenizer should not
-      // have created an `=` token. In practice the tokenizer groups
-      // `PropertyName='createdon'` into one ident `PropertyName=` then a
-      // string `createdon`. Let's check for that.
-      // (We've trimmed identifiers on ',' / ':' / '(' / ')' / quote / bracket
-      // so `PropertyName='x'` becomes ident=`PropertyName=`, string=`x`. Adjust.)
-    }
-    // Strip trailing `=` if present.
-    if (name.endsWith('=')) name = name.slice(0, -1);
+	const out: DvFnArgs = {};
+	// Each arg: `Name=Value` or `Name='Value'` or `Name=[...]`. Separated by `,`.
+	// Use the comma-after-(close-paren-of-depth-0) logic since values can be
+	// bracket arrays which the tokenizer already groups.
+	while (ctx.toks[ctx.pos] && ctx.toks[ctx.pos].kind !== "rparen") {
+		const nameTok = ctx.toks[ctx.pos++];
+		if (nameTok.kind !== "ident")
+			throw new Error(`Expected argument name, got \`${nameTok.value}\`.`);
+		// The argument name might come WITH `=Value` glued on as one token, since
+		// the tokenizer doesn't split on `=`. Handle both shapes.
+		let name = nameTok.value;
+		let valueRaw: string | undefined;
+		const eqIdx = name.indexOf("=");
+		if (eqIdx >= 0) {
+			valueRaw = name.slice(eqIdx + 1);
+			name = name.slice(0, eqIdx);
+		} else {
+			// The `=` is in the next token's prefix — but the tokenizer should not
+			// have created an `=` token. In practice the tokenizer groups
+			// `PropertyName='createdon'` into one ident `PropertyName=` then a
+			// string `createdon`. Let's check for that.
+			// (We've trimmed identifiers on ',' / ':' / '(' / ')' / quote / bracket
+			// so `PropertyName='x'` becomes ident=`PropertyName=`, string=`x`. Adjust.)
+		}
+		// Strip trailing `=` if present.
+		if (name.endsWith("=")) name = name.slice(0, -1);
 
-    let argValue: { kind: 'scalar'; v: string } | { kind: 'array'; v: string[] };
-    if (valueRaw !== undefined && valueRaw !== '') {
-      argValue = { kind: 'scalar', v: stripQuotes(valueRaw) };
-    } else {
-      const valTok = ctx.toks[ctx.pos++];
-      if (!valTok) throw new Error(`Argument \`${name}\` is missing a value.`);
-      if (valTok.kind === 'string')      argValue = { kind: 'scalar', v: valTok.value };
-      else if (valTok.kind === 'number') argValue = { kind: 'scalar', v: valTok.value };
-      else if (valTok.kind === 'ident')  argValue = { kind: 'scalar', v: valTok.value };
-      else if (valTok.kind === 'bracket') argValue = { kind: 'array', v: parseBracketArray(valTok.value) };
-      else throw new Error(`Unexpected token \`${valTok.value}\` for argument \`${name}\`.`);
-    }
+		let argValue: { kind: "scalar"; v: string } | { kind: "array"; v: string[] };
+		if (valueRaw !== undefined && valueRaw !== "") {
+			argValue = { kind: "scalar", v: stripQuotes(valueRaw) };
+		} else {
+			const valTok = ctx.toks[ctx.pos++];
+			if (!valTok) throw new Error(`Argument \`${name}\` is missing a value.`);
+			if (valTok.kind === "string") argValue = { kind: "scalar", v: valTok.value };
+			else if (valTok.kind === "number") argValue = { kind: "scalar", v: valTok.value };
+			else if (valTok.kind === "ident") argValue = { kind: "scalar", v: valTok.value };
+			else if (valTok.kind === "bracket")
+				argValue = { kind: "array", v: parseBracketArray(valTok.value) };
+			else throw new Error(`Unexpected token \`${valTok.value}\` for argument \`${name}\`.`);
+		}
 
-    if (name === 'PropertyName')        out.PropertyName        = argValue.kind === 'scalar' ? argValue.v : '';
-    else if (name === 'PropertyValue')  out.PropertyValue       = argValue.kind === 'scalar' ? argValue.v : '';
-    else if (name === 'PropertyValue1') out.PropertyValue1      = argValue.kind === 'scalar' ? argValue.v : '';
-    else if (name === 'PropertyValue2') out.PropertyValue2      = argValue.kind === 'scalar' ? argValue.v : '';
-    else if (name === 'PropertyValues') out.PropertyValues      = argValue.kind === 'array'  ? argValue.v : [];
-    // Unknown arg → ignored silently (caller surfaces via the unknown-fn warning).
+		if (name === "PropertyName") out.PropertyName = argValue.kind === "scalar" ? argValue.v : "";
+		else if (name === "PropertyValue")
+			out.PropertyValue = argValue.kind === "scalar" ? argValue.v : "";
+		else if (name === "PropertyValue1")
+			out.PropertyValue1 = argValue.kind === "scalar" ? argValue.v : "";
+		else if (name === "PropertyValue2")
+			out.PropertyValue2 = argValue.kind === "scalar" ? argValue.v : "";
+		else if (name === "PropertyValues")
+			out.PropertyValues = argValue.kind === "array" ? argValue.v : [];
+		// Unknown arg → ignored silently (caller surfaces via the unknown-fn warning).
 
-    // Consume trailing comma if present.
-    if (ctx.toks[ctx.pos]?.kind === 'comma') ctx.pos++;
-  }
-  return out;
+		// Consume trailing comma if present.
+		if (ctx.toks[ctx.pos]?.kind === "comma") ctx.pos++;
+	}
+	return out;
 }
 
 /** `['1000','5000']` → ['1000', '5000']. Tolerant of unquoted ints. */
 function parseBracketArray(raw: string): string[] {
-  try {
-    // Dataverse PropertyValues uses single-quoted strings inside the array
-    // (e.g. `['1000','5000']`). JSON requires double quotes. Convert.
-    const jsonish = raw.replace(/'/g, '"');
-    const parsed = JSON.parse(jsonish);
-    return Array.isArray(parsed) ? parsed.map(v => String(v)) : [String(parsed)];
-  } catch {
-    // Fallback: strip brackets, split by comma, trim quotes.
-    return raw
-      .replace(/^\[/, '').replace(/\]$/, '')
-      .split(',')
-      .map(s => stripQuotes(s.trim()))
-      .filter(Boolean);
-  }
+	try {
+		// Dataverse PropertyValues uses single-quoted strings inside the array
+		// (e.g. `['1000','5000']`). JSON requires double quotes. Convert.
+		const jsonish = raw.replace(/'/g, '"');
+		const parsed = JSON.parse(jsonish);
+		return Array.isArray(parsed) ? parsed.map((v) => String(v)) : [String(parsed)];
+	} catch {
+		// Fallback: strip brackets, split by comma, trim quotes.
+		return raw
+			.replace(/^\[/, "")
+			.replace(/\]$/, "")
+			.split(",")
+			.map((s) => stripQuotes(s.trim()))
+			.filter(Boolean);
+	}
 }
 
 function stripQuotes(s: string): string {
-  if (s.length >= 2 && s.startsWith("'") && s.endsWith("'")) return s.slice(1, -1);
-  if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) return s.slice(1, -1);
-  return s;
+	if (s.length >= 2 && s.startsWith("'") && s.endsWith("'")) return s.slice(1, -1);
+	if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) return s.slice(1, -1);
+	return s;
 }
 
-function parseLambda(ctx: ParseFilterCtx, navPath: string, lambdaKind: 'any' | 'all'): FilterLambdaNode {
-  ctx.pos++; // consume the path ident
-  expect(ctx, 'lparen');
+function parseLambda(
+	ctx: ParseFilterCtx,
+	navPath: string,
+	lambdaKind: "any" | "all",
+): FilterLambdaNode {
+	ctx.pos++; // consume the path ident
+	expect(ctx, "lparen");
 
-  // navPath may carry an outer alias prefix (e.g. `c/Contact_Tasks`); strip it.
-  let nav = navPath;
-  if (ctx.outerAlias && nav.startsWith(ctx.outerAlias + '/')) {
-    nav = nav.slice(ctx.outerAlias.length + 1);
-  }
+	// navPath may carry an outer alias prefix (e.g. `c/Contact_Tasks`); strip it.
+	let nav = navPath;
+	if (ctx.outerAlias && nav.startsWith(ctx.outerAlias + "/")) {
+		nav = nav.slice(ctx.outerAlias.length + 1);
+	}
 
-  // Empty lambda `any()` — no alias, no body.
-  if (ctx.toks[ctx.pos]?.kind === 'rparen') {
-    ctx.pos++;
-    return {
-      id: newId('l'),
-      type: 'lambda',
-      nav,
-      lambda: lambdaKind,
-      alias: nav[0] ?? 'x',
-      inner: emptyFilterGroup(),
-    };
-  }
+	// Empty lambda `any()` — no alias, no body.
+	if (ctx.toks[ctx.pos]?.kind === "rparen") {
+		ctx.pos++;
+		return {
+			id: newId("l"),
+			type: "lambda",
+			nav,
+			lambda: lambdaKind,
+			alias: nav[0] ?? "x",
+			inner: emptyFilterGroup(),
+		};
+	}
 
-  // Otherwise: <alias> : <inner predicate>
-  const aliasTok = ctx.toks[ctx.pos++];
-  if (aliasTok.kind !== 'ident') throw new Error(`Lambda expected an alias, got \`${aliasTok.value}\`.`);
-  const alias = aliasTok.value;
-  expect(ctx, 'colon');
+	// Otherwise: <alias> : <inner predicate>
+	const aliasTok = ctx.toks[ctx.pos++];
+	if (aliasTok.kind !== "ident")
+		throw new Error(`Lambda expected an alias, got \`${aliasTok.value}\`.`);
+	const alias = aliasTok.value;
+	expect(ctx, "colon");
 
-  // Parse inner predicate up to the matching ')'. Recurse with this alias
-  // installed as outerAlias so nested lambdas can strip it from their nav.
-  const savedOuter = ctx.outerAlias;
-  ctx.outerAlias = alias;
-  const inner = parseOrExpr(ctx);
-  ctx.outerAlias = savedOuter;
-  expect(ctx, 'rparen');
+	// Parse inner predicate up to the matching ')'. Recurse with this alias
+	// installed as outerAlias so nested lambdas can strip it from their nav.
+	const savedOuter = ctx.outerAlias;
+	ctx.outerAlias = alias;
+	const inner = parseOrExpr(ctx);
+	ctx.outerAlias = savedOuter;
+	expect(ctx, "rparen");
 
-  const innerGroup: FilterGroup = inner.type === 'group'
-    ? inner
-    : { id: newId('g'), type: 'group', combinator: 'and', rules: [inner] };
+	const innerGroup: FilterGroup =
+		inner.type === "group"
+			? inner
+			: { id: newId("g"), type: "group", combinator: "and", rules: [inner] };
 
-  return {
-    id: newId('l'),
-    type: 'lambda',
-    nav,
-    lambda: lambdaKind,
-    alias,
-    inner: innerGroup,
-  };
+	return {
+		id: newId("l"),
+		type: "lambda",
+		nav,
+		lambda: lambdaKind,
+		alias,
+		inner: innerGroup,
+	};
 }
 
 // ── Filter helpers ──────────────────────────────────────────────────────
 
 function rewriteLookupValueInPath(p: string): string {
-  // Walk segments; decode `_<x>_value` on each one.
-  // Filter contexts don't easily know the leaf table when walking a
-  // nav-path (would need recursive nav-walking metadata), so we run
-  // without a table. Following the same conservative-preserve rule as
-  // decodeLookupValueForm: when metadata is unavailable, leave the
-  // `_X_value` wire form intact so the encoder's pass-through behavior
-  // produces a faithful round-trip. Decoding without metadata risks
-  // emitting a bare name the encoder can't re-wrap.
-  return p.split('/').map(seg => decodeLookupValueForm(seg)).join('/');
+	// Walk segments; decode `_<x>_value` on each one.
+	// Filter contexts don't easily know the leaf table when walking a
+	// nav-path (would need recursive nav-walking metadata), so we run
+	// without a table. Following the same conservative-preserve rule as
+	// decodeLookupValueForm: when metadata is unavailable, leave the
+	// `_X_value` wire form intact so the encoder's pass-through behavior
+	// produces a faithful round-trip. Decoding without metadata risks
+	// emitting a bare name the encoder can't re-wrap.
+	return p
+		.split("/")
+		.map((seg) => decodeLookupValueForm(seg))
+		.join("/");
 }
 
 function looksLikeGuid(s: string): boolean {
-  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(s);
+	return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(s);
 }
 
 function looksLikeIsoDate(s: string): boolean {
-  // Accepts:
-  //   2024-01-01                            date-only
-  //   2024-01-01T00:00                      datetime w/o seconds
-  //   2024-01-01T00:00:00                   datetime w/ seconds
-  //   2024-01-01T00:00:00.123                datetime w/ fractional seconds
-  //   any of the above + 'Z' | '+05:30' | '-08:00'  zone designator
-  return /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?$/.test(s);
+	// Accepts:
+	//   2024-01-01                            date-only
+	//   2024-01-01T00:00                      datetime w/o seconds
+	//   2024-01-01T00:00:00                   datetime w/ seconds
+	//   2024-01-01T00:00:00.123                datetime w/ fractional seconds
+	//   any of the above + 'Z' | '+05:30' | '-08:00'  zone designator
+	return /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?$/.test(s);
 }
 
 function isKeywordAhead(ctx: ParseFilterCtx, kw: string): boolean {
-  const t = ctx.toks[ctx.pos];
-  return !!t && t.kind === 'ident' && t.value.toLowerCase() === kw;
+	const t = ctx.toks[ctx.pos];
+	return !!t && t.kind === "ident" && t.value.toLowerCase() === kw;
 }
 
 function consumeKeyword(ctx: ParseFilterCtx, kw: string): void {
-  if (!isKeywordAhead(ctx, kw)) throw new Error(`Expected \`${kw}\` at position ${ctx.pos}.`);
-  ctx.pos++;
+	if (!isKeywordAhead(ctx, kw)) throw new Error(`Expected \`${kw}\` at position ${ctx.pos}.`);
+	ctx.pos++;
 }
 
-function expect(ctx: ParseFilterCtx, kind: Tok['kind']): void {
-  const t = ctx.toks[ctx.pos];
-  if (!t || t.kind !== kind) throw new Error(`Expected ${kind} at position ${ctx.pos}, got ${t?.kind ?? 'EOF'}.`);
-  ctx.pos++;
+function expect(ctx: ParseFilterCtx, kind: Tok["kind"]): void {
+	const t = ctx.toks[ctx.pos];
+	if (!t || t.kind !== kind)
+		throw new Error(`Expected ${kind} at position ${ctx.pos}, got ${t?.kind ?? "EOF"}.`);
+	ctx.pos++;
 }
 
 // ── $expand parser ──────────────────────────────────────────────────────
 
-function parseExpand(input: string, parentTable: TableMeta | undefined): { items: ExpandSpec[]; warnings: ParseIssue[]; errors: ParseIssue[] } {
-  const warnings: ParseIssue[] = [];
-  const errors: ParseIssue[] = [];
-  // Top-level comma-separated expand items.
-  const parts = topLevelSplit(input, ',').map(s => s.trim()).filter(Boolean);
-  const items = parts.map(p => parseOneExpand(p, parentTable, warnings, errors)).filter((x): x is ExpandSpec => !!x);
-  return { items, warnings, errors };
+function parseExpand(
+	input: string,
+	parentTable: TableMeta | undefined,
+): { items: ExpandSpec[]; warnings: ParseIssue[]; errors: ParseIssue[] } {
+	const warnings: ParseIssue[] = [];
+	const errors: ParseIssue[] = [];
+	// Top-level comma-separated expand items.
+	const parts = topLevelSplit(input, ",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	const items = parts
+		.map((p) => parseOneExpand(p, parentTable, warnings, errors))
+		.filter((x): x is ExpandSpec => !!x);
+	return { items, warnings, errors };
 }
 
-function parseOneExpand(raw: string, parentTable: TableMeta | undefined, warnings: ParseIssue[], errors: ParseIssue[]): ExpandSpec | null {
-  // `<nav>` or `<nav>(opts)` or `<nav>/$ref`.
-  const navOpenIdx = raw.indexOf('(');
-  let nav: string;
-  let optsRaw = '';
-  if (navOpenIdx < 0) {
-    nav = raw.trim();
-  } else {
-    nav = raw.slice(0, navOpenIdx).trim();
-    // Strip surrounding parens around opts.
-    optsRaw = raw.slice(navOpenIdx + 1, raw.lastIndexOf(')')).trim();
-  }
+function parseOneExpand(
+	raw: string,
+	parentTable: TableMeta | undefined,
+	warnings: ParseIssue[],
+	errors: ParseIssue[],
+): ExpandSpec | null {
+	// `<nav>` or `<nav>(opts)` or `<nav>/$ref`.
+	const navOpenIdx = raw.indexOf("(");
+	let nav: string;
+	let optsRaw = "";
+	if (navOpenIdx < 0) {
+		nav = raw.trim();
+	} else {
+		nav = raw.slice(0, navOpenIdx).trim();
+		// Strip surrounding parens around opts.
+		optsRaw = raw.slice(navOpenIdx + 1, raw.lastIndexOf(")")).trim();
+	}
 
-  // `/$ref` suffix on a single-valued nav → we don't model $ref in DRS yet.
-  if (nav.endsWith('/$ref')) {
-    nav = nav.slice(0, -'/$ref'.length);
-    warnings.push(iss(
-      `\`$expand=${nav}/$ref\` was reduced to a plain \`$expand=${nav}\` — DRS doesn't render the $ref-only form.`,
-      DOCS.joinTables,
-    ));
-  }
+	// `/$ref` suffix on a single-valued nav → we don't model $ref in DRS yet.
+	if (nav.endsWith("/$ref")) {
+		nav = nav.slice(0, -"/$ref".length);
+		warnings.push(
+			iss(
+				`\`$expand=${nav}/$ref\` was reduced to a plain \`$expand=${nav}\` — DRS doesn't render the $ref-only form.`,
+				DOCS.joinTables,
+			),
+		);
+	}
 
-  const spec = makeExpandSpec(nav);
+	const spec = makeExpandSpec(nav);
 
-  if (!optsRaw) return spec;
+	if (!optsRaw) return spec;
 
-  const navMeta = parentTable?.navigationProperties.find(n => n.name === nav);
-  const targetTbl = navMeta ? findTable(navMeta.targetEntity) : undefined;
+	const navMeta = parentTable?.navigationProperties.find((n) => n.name === nav);
+	const targetTbl = navMeta ? findTable(navMeta.targetEntity) : undefined;
 
-  // Inner options are `$key=value` segments separated by `;`.
-  const innerOpts = topLevelSplit(optsRaw, ';').map(s => s.trim()).filter(Boolean);
-  for (const opt of innerOpts) {
-    const eq = opt.indexOf('=');
-    if (eq < 0) continue;
-    const k = opt.slice(0, eq);
-    const v = opt.slice(eq + 1);
-    switch (k) {
-      case '$select':  spec.select = parseSelect(v, targetTbl); break;
-      case '$orderby': spec.orderby = parseOrderby(v, targetTbl); break;
-      case '$top':     spec.top = parseIntOrNull(v); break;
-      case '$filter': {
-        const r = parseFilter(v, targetTbl);
-        spec.filter = r.group;
-        warnings.push(...r.warnings.map(w => prefixIss(`expand(${nav})`, w)));
-        errors.push(...r.errors.map(e => prefixIss(`expand(${nav})`, e)));
-        break;
-      }
-      case '$expand': {
-        const r = parseExpand(v, targetTbl);
-        spec.nestedExpand = r.items;
-        warnings.push(...r.warnings);
-        errors.push(...r.errors);
-        break;
-      }
-      default:
-        errors.push(iss(
-          `expand(${nav}): unsupported inner option \`${k}\` — DRS supports $select / $filter / $orderby / $top / $expand only.`,
-          DOCS.joinTables,
-        ));
-    }
-  }
-  return spec;
+	// Inner options are `$key=value` segments separated by `;`.
+	const innerOpts = topLevelSplit(optsRaw, ";")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	for (const opt of innerOpts) {
+		const eq = opt.indexOf("=");
+		if (eq < 0) continue;
+		const k = opt.slice(0, eq);
+		const v = opt.slice(eq + 1);
+		switch (k) {
+			case "$select":
+				spec.select = parseSelect(v, targetTbl);
+				break;
+			case "$orderby":
+				spec.orderby = parseOrderby(v, targetTbl);
+				break;
+			case "$top":
+				spec.top = parseIntOrNull(v);
+				break;
+			case "$filter": {
+				const r = parseFilter(v, targetTbl);
+				spec.filter = r.group;
+				warnings.push(...r.warnings.map((w) => prefixIss(`expand(${nav})`, w)));
+				errors.push(...r.errors.map((e) => prefixIss(`expand(${nav})`, e)));
+				break;
+			}
+			case "$expand": {
+				const r = parseExpand(v, targetTbl);
+				spec.nestedExpand = r.items;
+				warnings.push(...r.warnings);
+				errors.push(...r.errors);
+				break;
+			}
+			default:
+				errors.push(
+					iss(
+						`expand(${nav}): unsupported inner option \`${k}\` — DRS supports $select / $filter / $orderby / $top / $expand only.`,
+						DOCS.joinTables,
+					),
+				);
+		}
+	}
+	return spec;
 }
 
 // ── $apply parser ───────────────────────────────────────────────────────
 
-function parseApply(input: string, table: TableMeta | undefined): { spec: ApplySpec; warnings: ParseIssue[]; errors: ParseIssue[] } {
-  const warnings: ParseIssue[] = [];
-  const errors: ParseIssue[] = [];
-  const spec: ApplySpec = {
-    enabled: true,
-    prefilter: emptyFilterGroup(),
-    groupby: [],
-    aggregates: [],
-  };
-  const stages = topLevelSplit(input, '/').map(s => s.trim()).filter(Boolean);
-  for (const stage of stages) {
-    if (stage.startsWith('filter(') && stage.endsWith(')')) {
-      const body = stage.slice('filter('.length, -1);
-      const r = parseFilter(body, table);
-      spec.prefilter = r.group;
-      warnings.push(...r.warnings.map(w => prefixIss('apply/filter', w)));
-      errors.push(...r.errors.map(e => prefixIss('apply/filter', e)));
-    } else if (stage.startsWith('aggregate(') && stage.endsWith(')')) {
-      const body = stage.slice('aggregate('.length, -1);
-      spec.aggregates = parseAggregateList(body, warnings, errors);
-    } else if (stage.startsWith('groupby(') && stage.endsWith(')')) {
-      const body = stage.slice('groupby('.length, -1);
-      const r = parseGroupby(body, warnings, errors);
-      spec.groupby = r.cols;
-      if (r.aggregates) spec.aggregates = r.aggregates;
-    } else {
-      // Unknown $apply stage — `bottomcount`, `topcount`, `compute`, etc.
-      // Hard reject — DRS only models filter/groupby/aggregate.
-      errors.push(iss(
-        `$apply: unsupported stage \`${stage.split('(')[0]}(…)\`.`,
-        DOCS.aggregateData,
-      ));
-    }
-  }
-  return { spec, warnings, errors };
+function parseApply(
+	input: string,
+	table: TableMeta | undefined,
+): { spec: ApplySpec; warnings: ParseIssue[]; errors: ParseIssue[] } {
+	const warnings: ParseIssue[] = [];
+	const errors: ParseIssue[] = [];
+	const spec: ApplySpec = {
+		enabled: true,
+		prefilter: emptyFilterGroup(),
+		groupby: [],
+		aggregates: [],
+	};
+	const stages = topLevelSplit(input, "/")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	for (const stage of stages) {
+		if (stage.startsWith("filter(") && stage.endsWith(")")) {
+			const body = stage.slice("filter(".length, -1);
+			const r = parseFilter(body, table);
+			spec.prefilter = r.group;
+			warnings.push(...r.warnings.map((w) => prefixIss("apply/filter", w)));
+			errors.push(...r.errors.map((e) => prefixIss("apply/filter", e)));
+		} else if (stage.startsWith("aggregate(") && stage.endsWith(")")) {
+			const body = stage.slice("aggregate(".length, -1);
+			spec.aggregates = parseAggregateList(body, warnings, errors);
+		} else if (stage.startsWith("groupby(") && stage.endsWith(")")) {
+			const body = stage.slice("groupby(".length, -1);
+			const r = parseGroupby(body, warnings, errors);
+			spec.groupby = r.cols;
+			if (r.aggregates) spec.aggregates = r.aggregates;
+		} else {
+			// Unknown $apply stage — `bottomcount`, `topcount`, `compute`, etc.
+			// Hard reject — DRS only models filter/groupby/aggregate.
+			errors.push(
+				iss(`$apply: unsupported stage \`${stage.split("(")[0]}(…)\`.`, DOCS.aggregateData),
+			);
+		}
+	}
+	return { spec, warnings, errors };
 }
 
-function parseGroupby(body: string, warnings: ParseIssue[], errors: ParseIssue[]): { cols: string[]; aggregates?: ApplyAgg[] } {
-  const firstOpen = body.indexOf('(');
-  if (firstOpen !== 0) {
-    errors.push(iss(
-      `$apply/groupby: expected \`(\` at start of args, got \`${body[0] ?? 'EOF'}\`.`,
-      DOCS.aggregateData,
-    ));
-    return { cols: [] };
-  }
-  let depth = 0; let firstCloseIdx = -1;
-  for (let i = 0; i < body.length; i++) {
-    if (body[i] === '(') depth++;
-    else if (body[i] === ')') { depth--; if (depth === 0) { firstCloseIdx = i; break; } }
-  }
-  if (firstCloseIdx < 0) {
-    errors.push(iss('$apply/groupby: unbalanced parens.', DOCS.aggregateData));
-    return { cols: [] };
-  }
-  const colsRaw = body.slice(1, firstCloseIdx);
-  const cols = topLevelSplit(colsRaw, ',').map(s => s.trim()).filter(Boolean)
-    .map(c => rewriteLookupValueInPath(c));
+function parseGroupby(
+	body: string,
+	warnings: ParseIssue[],
+	errors: ParseIssue[],
+): { cols: string[]; aggregates?: ApplyAgg[] } {
+	const firstOpen = body.indexOf("(");
+	if (firstOpen !== 0) {
+		errors.push(
+			iss(
+				`$apply/groupby: expected \`(\` at start of args, got \`${body[0] ?? "EOF"}\`.`,
+				DOCS.aggregateData,
+			),
+		);
+		return { cols: [] };
+	}
+	let depth = 0;
+	let firstCloseIdx = -1;
+	for (let i = 0; i < body.length; i++) {
+		if (body[i] === "(") depth++;
+		else if (body[i] === ")") {
+			depth--;
+			if (depth === 0) {
+				firstCloseIdx = i;
+				break;
+			}
+		}
+	}
+	if (firstCloseIdx < 0) {
+		errors.push(iss("$apply/groupby: unbalanced parens.", DOCS.aggregateData));
+		return { cols: [] };
+	}
+	const colsRaw = body.slice(1, firstCloseIdx);
+	const cols = topLevelSplit(colsRaw, ",")
+		.map((s) => s.trim())
+		.filter(Boolean)
+		.map((c) => rewriteLookupValueInPath(c));
 
-  const rest = body.slice(firstCloseIdx + 1).trim();
-  if (!rest) return { cols };
-  if (rest.startsWith(',aggregate(') && rest.endsWith(')')) {
-    const aggBody = rest.slice(',aggregate('.length, -1);
-    return { cols, aggregates: parseAggregateList(aggBody, warnings, errors) };
-  }
-  errors.push(iss(
-    `$apply/groupby: unexpected trailing content after the cols list.`,
-    DOCS.aggregateData,
-  ));
-  return { cols };
+	const rest = body.slice(firstCloseIdx + 1).trim();
+	if (!rest) return { cols };
+	if (rest.startsWith(",aggregate(") && rest.endsWith(")")) {
+		const aggBody = rest.slice(",aggregate(".length, -1);
+		return { cols, aggregates: parseAggregateList(aggBody, warnings, errors) };
+	}
+	errors.push(
+		iss(`$apply/groupby: unexpected trailing content after the cols list.`, DOCS.aggregateData),
+	);
+	return { cols };
 }
 
-function parseAggregateList(body: string, _warnings: ParseIssue[], errors: ParseIssue[]): ApplyAgg[] {
-  const parts = topLevelSplit(body, ',').map(s => s.trim()).filter(Boolean);
-  const out: ApplyAgg[] = [];
-  for (const p of parts) {
-    const countMatch = p.match(/^\$count\s+as\s+(\S+)$/i);
-    if (countMatch) {
-      out.push({ col: '$count', fn: '$count', alias: countMatch[1] });
-      continue;
-    }
-    const m = p.match(/^(\S+)\s+with\s+(\w+)\s+as\s+(\S+)$/i);
-    if (!m) {
-      errors.push(iss(
-        `$apply/aggregate: couldn't parse \`${p}\` — expected \`<col> with <fn> as <alias>\` or \`$count as <alias>\`.`,
-        DOCS.aggregateData,
-      ));
-      continue;
-    }
-    const fn = m[2].toLowerCase();
-    if (!KNOWN_AGG_FNS.has(fn)) {
-      errors.push(iss(
-        `$apply/aggregate: function \`${fn}\` is not modeled by DRS — only sum / average / min / max / $count are supported.`,
-        DOCS.aggregateData,
-      ));
-      continue;
-    }
-    out.push({
-      col: rewriteLookupValueInPath(m[1]),
-      fn: fn as AggFn,
-      alias: m[3],
-    });
-  }
-  return out;
+function parseAggregateList(
+	body: string,
+	_warnings: ParseIssue[],
+	errors: ParseIssue[],
+): ApplyAgg[] {
+	const parts = topLevelSplit(body, ",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	const out: ApplyAgg[] = [];
+	for (const p of parts) {
+		const countMatch = p.match(/^\$count\s+as\s+(\S+)$/i);
+		if (countMatch) {
+			out.push({ col: "$count", fn: "$count", alias: countMatch[1] });
+			continue;
+		}
+		const m = p.match(/^(\S+)\s+with\s+(\w+)\s+as\s+(\S+)$/i);
+		if (!m) {
+			errors.push(
+				iss(
+					`$apply/aggregate: couldn't parse \`${p}\` — expected \`<col> with <fn> as <alias>\` or \`$count as <alias>\`.`,
+					DOCS.aggregateData,
+				),
+			);
+			continue;
+		}
+		const fn = m[2].toLowerCase();
+		if (!KNOWN_AGG_FNS.has(fn)) {
+			errors.push(
+				iss(
+					`$apply/aggregate: function \`${fn}\` is not modeled by DRS — only sum / average / min / max / $count are supported.`,
+					DOCS.aggregateData,
+				),
+			);
+			continue;
+		}
+		out.push({
+			col: rewriteLookupValueInPath(m[1]),
+			fn: fn as AggFn,
+			alias: m[3],
+		});
+	}
+	return out;
 }
 
 // ── Numeric helpers ─────────────────────────────────────────────────────
 
 function parseIntOrNull(s: string): number | null {
-  const n = parseInt(s, 10);
-  return Number.isFinite(n) ? n : null;
+	const n = parseInt(s, 10);
+	return Number.isFinite(n) ? n : null;
 }

--- a/src/host/metadataProvider.ts
+++ b/src/host/metadataProvider.ts
@@ -12,74 +12,79 @@
 // is the single source of truth. Repeat reads are free because the
 // loaders short-circuit on cache hit.
 
-import * as loader from './dataverseMetadata';
-import { __registerLiveTable, findTable, getLiveTables } from '../mock/metadata';
+import * as loader from "./dataverseMetadata";
+import { __registerLiveTable, findTable, getLiveTables } from "../mock/metadata";
 import type {
-  TableMeta, ColumnMeta, NavProperty, AlternateKeyDef,
-  AttributeTypeCode, SourceType,
-} from '../mock/metadata';
-import type {
-  EntityMetadata, AttributeMetadata, RelationshipMetadata,
-} from './pptbClient';
-import { metadataCache } from './cache';
+	TableMeta,
+	ColumnMeta,
+	NavProperty,
+	AlternateKeyDef,
+	AttributeTypeCode,
+	SourceType,
+} from "../mock/metadata";
+import type { EntityMetadata, AttributeMetadata, RelationshipMetadata } from "./pptbClient";
+import { metadataCache } from "./cache";
 
 // ── Public surface ──────────────────────────────────────────────────────
 
 export interface EntityListItem {
-  logicalName: string;
-  displayName: string;
-  entitySetName: string;
-  metadataId: string;
+	logicalName: string;
+	displayName: string;
+	entitySetName: string;
+	metadataId: string;
 }
 
 export interface MetadataProvider {
-  /** Lightweight entity list for the table picker. */
-  listEntities(): Promise<EntityListItem[]>;
-  /** Full `TableMeta` — attributes + relationships + alt keys. */
-  getTable(logical: string): Promise<TableMeta | undefined>;
-  /** Synchronous cached read for editors that need an instant value. */
-  peekTable(logical: string): TableMeta | undefined;
-  /** Invalidate one table; the next read refetches. */
-  invalidateTable(logical: string): void;
-  /** Nuke all caches + the live registry. The next read refetches. */
-  invalidateAll(): void;
-  /**
-   * Refresh in place: drop caches, then re-fetch every currently-registered
-   * table and re-publish it. Unlike `invalidateAll`, editors keep showing the
-   * (briefly stale) current data until fresh data lands, with no need to
-   * re-navigate. Wired to the Settings "Refresh metadata" button.
-   */
-  refreshAll(): Promise<void>;
+	/** Lightweight entity list for the table picker. */
+	listEntities(): Promise<EntityListItem[]>;
+	/** Full `TableMeta` — attributes + relationships + alt keys. */
+	getTable(logical: string): Promise<TableMeta | undefined>;
+	/** Synchronous cached read for editors that need an instant value. */
+	peekTable(logical: string): TableMeta | undefined;
+	/** Invalidate one table; the next read refetches. */
+	invalidateTable(logical: string): void;
+	/** Nuke all caches + the live registry. The next read refetches. */
+	invalidateAll(): void;
+	/**
+	 * Refresh in place: drop caches, then re-fetch every currently-registered
+	 * table and re-publish it. Unlike `invalidateAll`, editors keep showing the
+	 * (briefly stale) current data until fresh data lands, with no need to
+	 * re-navigate. Wired to the Settings "Refresh metadata" button.
+	 */
+	refreshAll(): Promise<void>;
 }
 
 // ── Raw → studio-shape mappers ─────────────────────────────────────────
 
-function labelOf(d: EntityMetadata['DisplayName'] | AttributeMetadata['DisplayName'], fallback: string): string {
-  return d?.UserLocalizedLabel?.Label || fallback;
+function labelOf(
+	d: EntityMetadata["DisplayName"] | AttributeMetadata["DisplayName"],
+	fallback: string,
+): string {
+	return d?.UserLocalizedLabel?.Label || fallback;
 }
 
 const ATTRIBUTE_TYPE_MAP: Record<string, AttributeTypeCode | undefined> = {
-  String: 'String',
-  Memo: 'Memo',
-  Integer: 'Integer',
-  BigInt: 'BigInt',
-  Decimal: 'Decimal',
-  Double: 'Double',
-  Money: 'Money',
-  Boolean: 'Boolean',
-  DateTime: 'DateTime',
-  Picklist: 'Picklist',
-  MultiSelectPicklist: 'MultiSelectPicklist',
-  Virtual: undefined,
-  State: 'State',
-  Status: 'Status',
-  Lookup: 'Lookup',
-  Customer: 'Customer',
-  Owner: 'Owner',
-  Uniqueidentifier: 'Uniqueidentifier',
-  EntityName: 'EntityName',
-  File: 'File',
-  Image: 'Image',
+	String: "String",
+	Memo: "Memo",
+	Integer: "Integer",
+	BigInt: "BigInt",
+	Decimal: "Decimal",
+	Double: "Double",
+	Money: "Money",
+	Boolean: "Boolean",
+	DateTime: "DateTime",
+	Picklist: "Picklist",
+	MultiSelectPicklist: "MultiSelectPicklist",
+	Virtual: undefined,
+	State: "State",
+	Status: "Status",
+	Lookup: "Lookup",
+	Customer: "Customer",
+	Owner: "Owner",
+	Uniqueidentifier: "Uniqueidentifier",
+	EntityName: "EntityName",
+	File: "File",
+	Image: "Image",
 };
 
 /**
@@ -93,183 +98,212 @@ const ATTRIBUTE_TYPE_MAP: Record<string, AttributeTypeCode | undefined> = {
  * https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/use-web-api-functions#address-lookup-and-customer-fields-in-functions).
  */
 function odataNameOf(attrType: AttributeTypeCode, logicalName: string): string {
-  if (attrType === 'Lookup' || attrType === 'Customer' || attrType === 'Owner') {
-    return `_${logicalName}_value`;
-  }
-  return logicalName;
+	if (attrType === "Lookup" || attrType === "Customer" || attrType === "Owner") {
+		return `_${logicalName}_value`;
+	}
+	return logicalName;
 }
 
 function mapAttribute(raw: AttributeMetadata): ColumnMeta | null {
-  const attrType = ATTRIBUTE_TYPE_MAP[raw.AttributeType];
-  if (!attrType) return null;
+	const attrType = ATTRIBUTE_TYPE_MAP[raw.AttributeType];
+	if (!attrType) return null;
 
-  // We intentionally do NOT drop `IsValidODataAttribute=false` columns.
-  // That flag is unreliable on inheritance-based entities (task, email,
-  // appointment, etc.) where most inherited attributes report false at
-  // the child level even though they're queryable at runtime via the
-  // parent. See pptbClient.getEntityAttributes for the full reasoning.
-  //
-  // The flag is still projected onto the column for diagnostics; some
-  // future "show all attrs including legacy ones" diagnostic mode might
-  // surface it.
+	// We intentionally do NOT drop `IsValidODataAttribute=false` columns.
+	// That flag is unreliable on inheritance-based entities (task, email,
+	// appointment, etc.) where most inherited attributes report false at
+	// the child level even though they're queryable at runtime via the
+	// parent. See pptbClient.getEntityAttributes for the full reasoning.
+	//
+	// The flag is still projected onto the column for diagnostics; some
+	// future "show all attrs including legacy ones" diagnostic mode might
+	// surface it.
 
-  // Required-level + write-eligibility — base projection too. Drives the
-  // FieldSetEditor's column filter (Create vs Update) and Create's
-  // required-field gate. `required` stays as the back-compat boolean
-  // (true iff SystemRequired or ApplicationRequired); the new
-  // `requiredLevel` is the granular four-value enum.
-  const requiredLevel = raw.RequiredLevel?.Value;
-  const required =
-    requiredLevel === 'SystemRequired' ||
-    requiredLevel === 'ApplicationRequired';
+	// Required-level + write-eligibility — base projection too. Drives the
+	// FieldSetEditor's column filter (Create vs Update) and Create's
+	// required-field gate. `required` stays as the back-compat boolean
+	// (true iff SystemRequired or ApplicationRequired); the new
+	// `requiredLevel` is the granular four-value enum.
+	const requiredLevel = raw.RequiredLevel?.Value;
+	const required = requiredLevel === "SystemRequired" || requiredLevel === "ApplicationRequired";
 
-  const base = {
-    logicalName: raw.LogicalName,
-    displayName: labelOf(raw.DisplayName, raw.LogicalName),
-    oDataName: odataNameOf(attrType, raw.LogicalName),
-    required,
-    requiredLevel,
-    isValidForCreate: raw.IsValidForCreate !== false, // default true if undefined
-    isValidForUpdate: raw.IsValidForUpdate !== false,
-    isValidForRead:   raw.IsValidForRead   !== false,
-    // Carried for diagnostics. Don't filter on it — see comment above.
-    isValidOData:     raw.IsValidODataAttribute !== false,
-    // Fetched on the basic projection alongside everything else — see
-    // `getEntityAttributes` $select in pptbClient.ts. Both flags drive
-    // the filter-rule antipattern indicator (calculated / logical column).
-    isLogical: !!raw.IsLogical,
-    sourceType: (raw.SourceType ?? undefined) as SourceType | undefined,
-  } as const;
+	const base = {
+		logicalName: raw.LogicalName,
+		displayName: labelOf(raw.DisplayName, raw.LogicalName),
+		oDataName: odataNameOf(attrType, raw.LogicalName),
+		required,
+		requiredLevel,
+		isValidForCreate: raw.IsValidForCreate !== false, // default true if undefined
+		isValidForUpdate: raw.IsValidForUpdate !== false,
+		isValidForRead: raw.IsValidForRead !== false,
+		// Carried for diagnostics. Don't filter on it — see comment above.
+		isValidOData: raw.IsValidODataAttribute !== false,
+		// Fetched on the basic projection alongside everything else — see
+		// `getEntityAttributes` $select in pptbClient.ts. Both flags drive
+		// the filter-rule antipattern indicator (calculated / logical column).
+		isLogical: !!raw.IsLogical,
+		sourceType: (raw.SourceType ?? undefined) as SourceType | undefined,
+	} as const;
 
-  switch (attrType) {
-    case 'String':
-      return { ...base, attributeType: 'String', format: 'Text', maxLength: raw.MaxLength ?? 100 };
-    case 'Memo':
-      return { ...base, attributeType: 'Memo', format: 'Text', maxLength: raw.MaxLength ?? 2000 };
-    case 'Integer':
-      return { ...base, attributeType: 'Integer', format: 'None',
-        minValue: raw.MinValue, maxValue: raw.MaxValue };
-    case 'BigInt':
-      return { ...base, attributeType: 'BigInt', minValue: raw.MinValue, maxValue: raw.MaxValue };
-    case 'Decimal':
-      return { ...base, attributeType: 'Decimal', precision: raw.Precision ?? 2,
-        minValue: raw.MinValue, maxValue: raw.MaxValue };
-    case 'Double':
-      return { ...base, attributeType: 'Double', precision: raw.Precision ?? 2,
-        minValue: raw.MinValue, maxValue: raw.MaxValue };
-    case 'Money':
-      return { ...base, attributeType: 'Money', precisionSource: 1, precision: raw.Precision ?? 2,
-        minValue: raw.MinValue, maxValue: raw.MaxValue };
-    case 'Boolean':
-      return { ...base, attributeType: 'Boolean',
-        trueOption:  { value: 1, label: labelOf(raw.OptionSet?.TrueOption?.Label, 'Yes') },
-        falseOption: { value: 0, label: labelOf(raw.OptionSet?.FalseOption?.Label, 'No') } };
-    case 'DateTime':
-      return { ...base, attributeType: 'DateTime',
-        format: (raw.Format as 'DateAndTime' | 'DateOnly') ?? 'DateAndTime',
-        dateTimeBehavior: (raw.DateTimeBehavior?.Value as 'UserLocal' | 'DateOnly' | 'TimeZoneIndependent') ?? 'UserLocal' };
-    case 'Picklist':
-    case 'MultiSelectPicklist':
-    case 'State':
-    case 'EntityName': {
-      const opts = (raw.OptionSet?.Options ?? []).map(o => ({
-        value: o.Value, label: labelOf(o.Label, String(o.Value)),
-      }));
-      return { ...base, attributeType: attrType, options: opts };
-    }
-    case 'Status': {
-      const opts = (raw.OptionSet?.Options ?? []).map(o => ({
-        value: o.Value, label: labelOf(o.Label, String(o.Value)), state: 0,
-      }));
-      return { ...base, attributeType: 'Status', options: opts };
-    }
-    case 'Lookup':
-      return { ...base, attributeType: 'Lookup', targets: raw.Targets ?? [] };
-    case 'Customer':
-      return { ...base, attributeType: 'Customer', targets: raw.Targets ?? ['account', 'contact'] };
-    case 'Owner':
-      return { ...base, attributeType: 'Owner', targets: raw.Targets ?? ['systemuser', 'team'] };
-    case 'Uniqueidentifier':
-      return { ...base, attributeType: 'Uniqueidentifier' };
-    case 'File':
-      return { ...base, attributeType: 'File' };
-    case 'Image':
-      return { ...base, attributeType: 'Image' };
-  }
+	switch (attrType) {
+		case "String":
+			return { ...base, attributeType: "String", format: "Text", maxLength: raw.MaxLength ?? 100 };
+		case "Memo":
+			return { ...base, attributeType: "Memo", format: "Text", maxLength: raw.MaxLength ?? 2000 };
+		case "Integer":
+			return {
+				...base,
+				attributeType: "Integer",
+				format: "None",
+				minValue: raw.MinValue,
+				maxValue: raw.MaxValue,
+			};
+		case "BigInt":
+			return { ...base, attributeType: "BigInt", minValue: raw.MinValue, maxValue: raw.MaxValue };
+		case "Decimal":
+			return {
+				...base,
+				attributeType: "Decimal",
+				precision: raw.Precision ?? 2,
+				minValue: raw.MinValue,
+				maxValue: raw.MaxValue,
+			};
+		case "Double":
+			return {
+				...base,
+				attributeType: "Double",
+				precision: raw.Precision ?? 2,
+				minValue: raw.MinValue,
+				maxValue: raw.MaxValue,
+			};
+		case "Money":
+			return {
+				...base,
+				attributeType: "Money",
+				precisionSource: 1,
+				precision: raw.Precision ?? 2,
+				minValue: raw.MinValue,
+				maxValue: raw.MaxValue,
+			};
+		case "Boolean":
+			return {
+				...base,
+				attributeType: "Boolean",
+				trueOption: { value: 1, label: labelOf(raw.OptionSet?.TrueOption?.Label, "Yes") },
+				falseOption: { value: 0, label: labelOf(raw.OptionSet?.FalseOption?.Label, "No") },
+			};
+		case "DateTime":
+			return {
+				...base,
+				attributeType: "DateTime",
+				format: (raw.Format as "DateAndTime" | "DateOnly") ?? "DateAndTime",
+				dateTimeBehavior:
+					(raw.DateTimeBehavior?.Value as "UserLocal" | "DateOnly" | "TimeZoneIndependent") ??
+					"UserLocal",
+			};
+		case "Picklist":
+		case "MultiSelectPicklist":
+		case "State":
+		case "EntityName": {
+			const opts = (raw.OptionSet?.Options ?? []).map((o) => ({
+				value: o.Value,
+				label: labelOf(o.Label, String(o.Value)),
+			}));
+			return { ...base, attributeType: attrType, options: opts };
+		}
+		case "Status": {
+			const opts = (raw.OptionSet?.Options ?? []).map((o) => ({
+				value: o.Value,
+				label: labelOf(o.Label, String(o.Value)),
+				state: 0,
+			}));
+			return { ...base, attributeType: "Status", options: opts };
+		}
+		case "Lookup":
+			return { ...base, attributeType: "Lookup", targets: raw.Targets ?? [] };
+		case "Customer":
+			return { ...base, attributeType: "Customer", targets: raw.Targets ?? ["account", "contact"] };
+		case "Owner":
+			return { ...base, attributeType: "Owner", targets: raw.Targets ?? ["systemuser", "team"] };
+		case "Uniqueidentifier":
+			return { ...base, attributeType: "Uniqueidentifier" };
+		case "File":
+			return { ...base, attributeType: "File" };
+		case "Image":
+			return { ...base, attributeType: "Image" };
+	}
 }
 
 function mapRelationships(
-  o2m: RelationshipMetadata[],
-  m2o: RelationshipMetadata[],
-  m2m: RelationshipMetadata[],
-  selfEntity: string,
+	o2m: RelationshipMetadata[],
+	m2o: RelationshipMetadata[],
+	m2m: RelationshipMetadata[],
+	selfEntity: string,
 ): NavProperty[] {
-  const out: NavProperty[] = [];
+	const out: NavProperty[] = [];
 
-  // ── N:1 (ManyToOne — lookups from this entity to a parent) ──
-  // Use ReferencingEntityNavigationPropertyName as the nav name. Critical
-  // for polymorphic Customer/Owner lookups: the OData schema does NOT
-  // expose the bare attribute name (e.g. `customerid`) as a nav property —
-  // it exposes target-disambiguated names (`customerid_account`,
-  // `customerid_contact`). Using the bare name in $expand fails with
-  // 0x80060888 "Could not find a property named 'customerid'…".
-  for (const r of m2o) {
-    const navName = r.ReferencingEntityNavigationPropertyName
-      || r.ReferencingAttribute
-      || r.SchemaName;
-    out.push({
-      name: navName,
-      relationshipName: r.SchemaName,
-      cardinality: 'ManyToOne',
-      targetEntity: r.ReferencedEntity ?? '',
-      // Source FK column name. Polymorphic lookups (Customer / Owner /
-      // multi-target Lookup) have multiple ManyToOne relationships sharing
-      // this same `referencingAttribute` but with different `targetEntity`
-      // and different `name`. The write-body encoder matches by
-      // (referencingAttribute, targetEntity) to pick the right
-      // `@odata.bind` property name. See urlBuilder.bindPropertyFor.
-      referencingAttribute: r.ReferencingAttribute,
-    });
-  }
+	// ── N:1 (ManyToOne — lookups from this entity to a parent) ──
+	// Use ReferencingEntityNavigationPropertyName as the nav name. Critical
+	// for polymorphic Customer/Owner lookups: the OData schema does NOT
+	// expose the bare attribute name (e.g. `customerid`) as a nav property —
+	// it exposes target-disambiguated names (`customerid_account`,
+	// `customerid_contact`). Using the bare name in $expand fails with
+	// 0x80060888 "Could not find a property named 'customerid'…".
+	for (const r of m2o) {
+		const navName =
+			r.ReferencingEntityNavigationPropertyName || r.ReferencingAttribute || r.SchemaName;
+		out.push({
+			name: navName,
+			relationshipName: r.SchemaName,
+			cardinality: "ManyToOne",
+			targetEntity: r.ReferencedEntity ?? "",
+			// Source FK column name. Polymorphic lookups (Customer / Owner /
+			// multi-target Lookup) have multiple ManyToOne relationships sharing
+			// this same `referencingAttribute` but with different `targetEntity`
+			// and different `name`. The write-body encoder matches by
+			// (referencingAttribute, targetEntity) to pick the right
+			// `@odata.bind` property name. See urlBuilder.bindPropertyFor.
+			referencingAttribute: r.ReferencingAttribute,
+		});
+	}
 
-  // ── 1:N (OneToMany — child collections off this entity) ──
-  // Use ReferencedEntityNavigationPropertyName when present; falls back
-  // to SchemaName for older metadata.
-  for (const r of o2m) {
-    const navName = r.ReferencedEntityNavigationPropertyName || r.SchemaName;
-    out.push({
-      name: navName,
-      relationshipName: r.SchemaName,
-      cardinality: 'OneToMany',
-      targetEntity: r.ReferencingEntity ?? '',
-    });
-  }
+	// ── 1:N (OneToMany — child collections off this entity) ──
+	// Use ReferencedEntityNavigationPropertyName when present; falls back
+	// to SchemaName for older metadata.
+	for (const r of o2m) {
+		const navName = r.ReferencedEntityNavigationPropertyName || r.SchemaName;
+		out.push({
+			name: navName,
+			relationshipName: r.SchemaName,
+			cardinality: "OneToMany",
+			targetEntity: r.ReferencingEntity ?? "",
+		});
+	}
 
-  // ── N:N (ManyToMany) ──
-  // Each side has its own nav property name; pick the one belonging to
-  // self so the user sees "accountleads" not "leadaccounts" on `account`.
-  for (const r of m2m) {
-    const isEntity1 = r.Entity1LogicalName === selfEntity;
-    const navName =
-      (isEntity1 ? r.Entity1NavigationPropertyName : r.Entity2NavigationPropertyName)
-      || r.SchemaName;
-    out.push({
-      name: navName,
-      relationshipName: r.SchemaName,
-      cardinality: 'ManyToMany',
-      targetEntity: isEntity1 ? (r.Entity2LogicalName ?? '') : (r.Entity1LogicalName ?? ''),
-    });
-  }
-  return out;
+	// ── N:N (ManyToMany) ──
+	// Each side has its own nav property name; pick the one belonging to
+	// self so the user sees "accountleads" not "leadaccounts" on `account`.
+	for (const r of m2m) {
+		const isEntity1 = r.Entity1LogicalName === selfEntity;
+		const navName =
+			(isEntity1 ? r.Entity1NavigationPropertyName : r.Entity2NavigationPropertyName) ||
+			r.SchemaName;
+		out.push({
+			name: navName,
+			relationshipName: r.SchemaName,
+			cardinality: "ManyToMany",
+			targetEntity: isEntity1 ? (r.Entity2LogicalName ?? "") : (r.Entity1LogicalName ?? ""),
+		});
+	}
+	return out;
 }
 
 function mapEntityListItem(e: EntityMetadata): EntityListItem {
-  return {
-    logicalName: e.LogicalName,
-    displayName: labelOf(e.DisplayName, e.LogicalName),
-    entitySetName: e.EntitySetName,
-    metadataId: e.MetadataId,
-  };
+	return {
+		logicalName: e.LogicalName,
+		displayName: labelOf(e.DisplayName, e.LogicalName),
+		entitySetName: e.EntitySetName,
+		metadataId: e.MetadataId,
+	};
 }
 
 // ── Provider impl ──────────────────────────────────────────────────────
@@ -277,133 +311,138 @@ function mapEntityListItem(e: EntityMetadata): EntityListItem {
 let buildInFlight = new Map<string, Promise<TableMeta | undefined>>();
 
 async function buildTable(logical: string): Promise<TableMeta | undefined> {
-  // Dedupe concurrent builds for the same entity.
-  const existing = buildInFlight.get(logical);
-  if (existing) return existing;
+	// Dedupe concurrent builds for the same entity.
+	const existing = buildInFlight.get(logical);
+	if (existing) return existing;
 
-  const promise = (async () => {
-    try {
-      // Basic load: 3 HTTP requests per entity, period.
-      //   1. Entity metadata (PrimaryIdAttribute, EntitySetName, …)
-      //   2. Basic attribute projection (LogicalName + DisplayName +
-      //      AttributeType — no Targets, no OptionSet, no MaxLength)
-      //   3. Relationships (1:N + N:1 + N:N)
-      //
-      // Type-specific properties (Targets for lookups, OptionSet for
-      // picklists, MaxLength/Format for strings, MinValue/MaxValue/Precision
-      // for numerics, etc.) are NOT fetched here — they're loaded lazily
-      // per-column on demand by `useColumnDetail` when an editor needs them.
-      // Keeping this initial load small is what stops us tripping Dataverse's
-      // 100-concurrent-request cap.
-      const [entity, attrs, rels, keys] = await Promise.all([
-        loader.loadEntityMetadata(logical),
-        loader.loadEntityAttributes(logical),
-        loader.loadEntityRelationships(logical),
-        // Alternate keys — separate /Keys child collection. Cheap fetch
-        // (most entities have 0-2 keys) and we need it eagerly so Upsert
-        // mode's alt-key picker is populated when the user lands on it.
-        loader.loadEntityKeys(logical),
-      ]);
+	const promise = (async () => {
+		try {
+			// Basic load: 3 HTTP requests per entity, period.
+			//   1. Entity metadata (PrimaryIdAttribute, EntitySetName, …)
+			//   2. Basic attribute projection (LogicalName + DisplayName +
+			//      AttributeType — no Targets, no OptionSet, no MaxLength)
+			//   3. Relationships (1:N + N:1 + N:N)
+			//
+			// Type-specific properties (Targets for lookups, OptionSet for
+			// picklists, MaxLength/Format for strings, MinValue/MaxValue/Precision
+			// for numerics, etc.) are NOT fetched here — they're loaded lazily
+			// per-column on demand by `useColumnDetail` when an editor needs them.
+			// Keeping this initial load small is what stops us tripping Dataverse's
+			// 100-concurrent-request cap.
+			const [entity, attrs, rels, keys] = await Promise.all([
+				loader.loadEntityMetadata(logical),
+				loader.loadEntityAttributes(logical),
+				loader.loadEntityRelationships(logical),
+				// Alternate keys — separate /Keys child collection. Cheap fetch
+				// (most entities have 0-2 keys) and we need it eagerly so Upsert
+				// mode's alt-key picker is populated when the user lands on it.
+				loader.loadEntityKeys(logical),
+			]);
 
-      const columns = attrs.map(mapAttribute).filter((c): c is ColumnMeta => c !== null);
+			const columns = attrs.map(mapAttribute).filter((c): c is ColumnMeta => c !== null);
 
-      // Mark the primary key.
-      const pk = columns.find(c => c.logicalName === entity.PrimaryIdAttribute);
-      if (pk && pk.attributeType === 'Uniqueidentifier') pk.isPrimaryKey = true;
+			// Mark the primary key.
+			const pk = columns.find((c) => c.logicalName === entity.PrimaryIdAttribute);
+			if (pk && pk.attributeType === "Uniqueidentifier") pk.isPrimaryKey = true;
 
-      // Map the EntityKeyMetadata projection into our lightweight
-      // AlternateKeyDef shape. We keep only Active keys — Pending /
-      // Failed status means the index isn't ready and Upsert will fail
-      // at runtime. (We could surface Pending as a disabled option later
-      // with a "key not ready yet" tooltip; for now: hide.)
-      const alternateKeys: AlternateKeyDef[] = keys
-        .filter(k => k.EntityKeyIndexStatus === 'Active')
-        .map(k => ({
-          name: k.LogicalName,
-          displayName: k.DisplayName?.UserLocalizedLabel?.Label ?? k.LogicalName,
-          columns: k.KeyAttributes ?? [],
-        }))
-        .filter(k => k.columns.length > 0);
+			// Map the EntityKeyMetadata projection into our lightweight
+			// AlternateKeyDef shape. We keep only Active keys — Pending /
+			// Failed status means the index isn't ready and Upsert will fail
+			// at runtime. (We could surface Pending as a disabled option later
+			// with a "key not ready yet" tooltip; for now: hide.)
+			const alternateKeys: AlternateKeyDef[] = keys
+				.filter((k) => k.EntityKeyIndexStatus === "Active")
+				.map((k) => ({
+					name: k.LogicalName,
+					displayName: k.DisplayName?.UserLocalizedLabel?.Label ?? k.LogicalName,
+					columns: k.KeyAttributes ?? [],
+				}))
+				.filter((k) => k.columns.length > 0);
 
-      const built: TableMeta = {
-        logicalName: entity.LogicalName,
-        entitySetName: entity.EntitySetName,
-        displayName: labelOf(entity.DisplayName, entity.LogicalName),
-        primaryKey: entity.PrimaryIdAttribute,
-        primaryName: entity.PrimaryNameAttribute,
-        columns,
-        navigationProperties: mapRelationships(rels.oneToMany, rels.manyToOne, rels.manyToMany, logical),
-        alternateKeys,
-        supportsMerge: ['account', 'contact', 'incident'].includes(logical),
-      };
+			const built: TableMeta = {
+				logicalName: entity.LogicalName,
+				entitySetName: entity.EntitySetName,
+				displayName: labelOf(entity.DisplayName, entity.LogicalName),
+				primaryKey: entity.PrimaryIdAttribute,
+				primaryName: entity.PrimaryNameAttribute,
+				columns,
+				navigationProperties: mapRelationships(
+					rels.oneToMany,
+					rels.manyToOne,
+					rels.manyToMany,
+					logical,
+				),
+				alternateKeys,
+				supportsMerge: ["account", "contact", "incident"].includes(logical),
+			};
 
-      // Publish into the synchronous registry — this is what makes the
-      // ~22 editors that call `findTable(logical)` synchronously see the
-      // live data (after a re-render triggered by mode-level
-      // `useLiveTable`).
-      __registerLiveTable(built);
-      return built;
-    } catch (e) {
-      console.error(`[metadataProvider] getTable('${logical}') failed:`, e);
-      return undefined;
-    } finally {
-      buildInFlight.delete(logical);
-    }
-  })();
+			// Publish into the synchronous registry — this is what makes the
+			// ~22 editors that call `findTable(logical)` synchronously see the
+			// live data (after a re-render triggered by mode-level
+			// `useLiveTable`).
+			__registerLiveTable(built);
+			return built;
+		} catch (e) {
+			console.error(`[metadataProvider] getTable('${logical}') failed:`, e);
+			return undefined;
+		} finally {
+			buildInFlight.delete(logical);
+		}
+	})();
 
-  buildInFlight.set(logical, promise);
-  return promise;
+	buildInFlight.set(logical, promise);
+	return promise;
 }
 
 export const metadata: MetadataProvider = {
-  async listEntities(): Promise<EntityListItem[]> {
-    const all = await loader.loadAllEntities();
-    return all.map(mapEntityListItem);
-  },
+	async listEntities(): Promise<EntityListItem[]> {
+		const all = await loader.loadAllEntities();
+		return all.map(mapEntityListItem);
+	},
 
-  async getTable(logical: string): Promise<TableMeta | undefined> {
-    // Synchronous cache hit (already-registered) → done.
-    const live = findTable(logical);
-    if (live) return live;
-    return buildTable(logical);
-  },
+	async getTable(logical: string): Promise<TableMeta | undefined> {
+		// Synchronous cache hit (already-registered) → done.
+		const live = findTable(logical);
+		if (live) return live;
+		return buildTable(logical);
+	},
 
-  peekTable(logical: string): TableMeta | undefined {
-    return findTable(logical);
-  },
+	peekTable(logical: string): TableMeta | undefined {
+		return findTable(logical);
+	},
 
-  invalidateTable(logical: string): void {
-    metadataCache.clearEntity(logical);
-    buildInFlight.delete(logical);
-  },
+	invalidateTable(logical: string): void {
+		metadataCache.clearEntity(logical);
+		buildInFlight.delete(logical);
+	},
 
-  invalidateAll(): void {
-    metadataCache.clear();
-    buildInFlight = new Map();
-    // Also clear the synchronous registry so editors don't show stale data.
-    // The next mode-level `useLiveTable` fetch will repopulate.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    import('../mock/metadata').then(({ __clearLiveTables }) => __clearLiveTables());
-  },
+	invalidateAll(): void {
+		metadataCache.clear();
+		buildInFlight = new Map();
+		// Also clear the synchronous registry so editors don't show stale data.
+		// The next mode-level `useLiveTable` fetch will repopulate.
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		import("../mock/metadata").then(({ __clearLiveTables }) => __clearLiveTables());
+	},
 
-  async refreshAll(): Promise<void> {
-    // Drain any currently in-flight builds before touching the cache.
-    // Without this, an orphaned buildTable promise can settle AFTER the
-    // cache clear and re-register a pre-refresh TableMeta, silently
-    // overwriting the fresh data we're about to fetch (race on
-    // __registerLiveTable). allSettled so a failing fetch doesn't abort.
-    await Promise.allSettled([...buildInFlight.values()]);
+	async refreshAll(): Promise<void> {
+		// Drain any currently in-flight builds before touching the cache.
+		// Without this, an orphaned buildTable promise can settle AFTER the
+		// cache clear and re-register a pre-refresh TableMeta, silently
+		// overwriting the fresh data we're about to fetch (race on
+		// __registerLiveTable). allSettled so a failing fetch doesn't abort.
+		await Promise.allSettled([...buildInFlight.values()]);
 
-    // Snapshot what's currently registered, drop caches, then rebuild each
-    // table. `buildTable` always hits the network (cache just cleared) and
-    // re-registers via `__registerLiveTable`, firing the registry listeners
-    // so every editor re-renders with fresh data. We deliberately do NOT
-    // clear the registry first, so the UI shows current data until each
-    // table's refresh lands. The set is small (current target + warmed
-    // related entities), keeping us clear of the 100-concurrent cap.
-    const logicals = getLiveTables().map(t => t.logicalName);
-    metadataCache.clear();
-    buildInFlight = new Map();
-    await Promise.all(logicals.map(l => buildTable(l)));
-  },
+		// Snapshot what's currently registered, drop caches, then rebuild each
+		// table. `buildTable` always hits the network (cache just cleared) and
+		// re-registers via `__registerLiveTable`, firing the registry listeners
+		// so every editor re-renders with fresh data. We deliberately do NOT
+		// clear the registry first, so the UI shows current data until each
+		// table's refresh lands. The set is small (current target + warmed
+		// related entities), keeping us clear of the 100-concurrent cap.
+		const logicals = getLiveTables().map((t) => t.logicalName);
+		metadataCache.clear();
+		buildInFlight = new Map();
+		await Promise.all(logicals.map((l) => buildTable(l)));
+	},
 };

--- a/src/host/metadataProvider.ts
+++ b/src/host/metadataProvider.ts
@@ -387,6 +387,13 @@ export const metadata: MetadataProvider = {
   },
 
   async refreshAll(): Promise<void> {
+    // Drain any currently in-flight builds before touching the cache.
+    // Without this, an orphaned buildTable promise can settle AFTER the
+    // cache clear and re-register a pre-refresh TableMeta, silently
+    // overwriting the fresh data we're about to fetch (race on
+    // __registerLiveTable). allSettled so a failing fetch doesn't abort.
+    await Promise.allSettled([...buildInFlight.values()]);
+
     // Snapshot what's currently registered, drop caches, then rebuild each
     // table. `buildTable` always hits the network (cache just cleared) and
     // re-registers via `__registerLiveTable`, firing the registry listeners

--- a/src/mock/metadata.ts
+++ b/src/mock/metadata.ts
@@ -37,19 +37,43 @@
 // Attribute type code (subset that's relevant to filter UX)
 // ============================================================
 export type AttributeTypeCode =
-  | 'BigInt' | 'Boolean' | 'Customer' | 'DateTime' | 'Decimal' | 'Double'
-  | 'EntityName' | 'File' | 'Image' | 'Integer' | 'Lookup' | 'Memo'
-  | 'Money' | 'Owner' | 'Picklist' | 'State' | 'Status' | 'String'
-  | 'Uniqueidentifier' | 'MultiSelectPicklist';
+	| "BigInt"
+	| "Boolean"
+	| "Customer"
+	| "DateTime"
+	| "Decimal"
+	| "Double"
+	| "EntityName"
+	| "File"
+	| "Image"
+	| "Integer"
+	| "Lookup"
+	| "Memo"
+	| "Money"
+	| "Owner"
+	| "Picklist"
+	| "State"
+	| "Status"
+	| "String"
+	| "Uniqueidentifier"
+	| "MultiSelectPicklist";
 
 // ============================================================
 // Format enums (per the AttributeMetadata classes)
 // ============================================================
-export type StringFormat = 'Email' | 'Text' | 'TextArea' | 'Url' | 'Phone' | 'TickerSymbol' | 'VersionNumber' | 'PhoneticGuide';
-export type MemoFormat = 'Email' | 'Text' | 'TextArea' | 'Url' | 'Phone';
-export type IntegerFormat = 'None' | 'Duration' | 'Language' | 'Locale' | 'TimeZone';
-export type DateTimeFormat = 'DateAndTime' | 'DateOnly';
-export type DateTimeBehavior = 'UserLocal' | 'DateOnly' | 'TimeZoneIndependent';
+export type StringFormat =
+	| "Email"
+	| "Text"
+	| "TextArea"
+	| "Url"
+	| "Phone"
+	| "TickerSymbol"
+	| "VersionNumber"
+	| "PhoneticGuide";
+export type MemoFormat = "Email" | "Text" | "TextArea" | "Url" | "Phone";
+export type IntegerFormat = "None" | "Duration" | "Language" | "Locale" | "TimeZone";
+export type DateTimeFormat = "DateAndTime" | "DateOnly";
+export type DateTimeBehavior = "UserLocal" | "DateOnly" | "TimeZoneIndependent";
 
 // ============================================================
 // SourceType — for specialized columns (calculated / rollup / formula).
@@ -70,230 +94,270 @@ export type SourceType = 0 | 1 | 2 | 3 | 4;
 // Discriminated column meta — one shape per AttributeTypeCode
 // ============================================================
 export interface BaseColumnMeta {
-  logicalName: string;
-  displayName: string;
-  /**
-   * Backwards-compat boolean — true iff `requiredLevel` is
-   * `SystemRequired` or `ApplicationRequired`. New code should read
-   * `requiredLevel` directly so it can distinguish system-locked from
-   * business-required (which the maker can change).
-   */
-  required?: boolean;
-  /**
-   * Granular required-level from AttributeMetadata.RequiredLevel.Value.
-   * Drives the Create mode's required-field gate.
-   */
-  requiredLevel?: 'None' | 'Recommended' | 'ApplicationRequired' | 'SystemRequired';
-  /** True iff this attribute can appear in a POST body (Create). False
-   *  for system-managed columns, formula/rollup outputs, etc. Drives the
-   *  FieldSetEditor's column filter in Create mode. */
-  isValidForCreate?: boolean;
-  /** True iff this attribute can appear in a PATCH body (Update). Often
-   *  a subset of isValidForCreate (write-once columns). Drives the
-   *  FieldSetEditor's column filter in Update mode. */
-  isValidForUpdate?: boolean;
-  /** True iff this attribute can be read. Always true on standard
-   *  attributes; surfaced for defensive $select filtering in Read modes. */
-  isValidForRead?: boolean;
-  /**
-   * True iff the attribute is exposed via the OData / Web API. Hard wall —
-   * if false, the attribute can't be selected, filtered, ordered, or
-   * written to. We filter server-side AND drop the column at
-   * mapAttribute time, so consumers should never see `false` here. The
-   * field is carried for diagnostics + future "show all attributes"
-   * affordances.
-   */
-  isValidOData?: boolean;
-  description?: string;
+	logicalName: string;
+	displayName: string;
+	/**
+	 * Backwards-compat boolean — true iff `requiredLevel` is
+	 * `SystemRequired` or `ApplicationRequired`. New code should read
+	 * `requiredLevel` directly so it can distinguish system-locked from
+	 * business-required (which the maker can change).
+	 */
+	required?: boolean;
+	/**
+	 * Granular required-level from AttributeMetadata.RequiredLevel.Value.
+	 * Drives the Create mode's required-field gate.
+	 */
+	requiredLevel?: "None" | "Recommended" | "ApplicationRequired" | "SystemRequired";
+	/** True iff this attribute can appear in a POST body (Create). False
+	 *  for system-managed columns, formula/rollup outputs, etc. Drives the
+	 *  FieldSetEditor's column filter in Create mode. */
+	isValidForCreate?: boolean;
+	/** True iff this attribute can appear in a PATCH body (Update). Often
+	 *  a subset of isValidForCreate (write-once columns). Drives the
+	 *  FieldSetEditor's column filter in Update mode. */
+	isValidForUpdate?: boolean;
+	/** True iff this attribute can be read. Always true on standard
+	 *  attributes; surfaced for defensive $select filtering in Read modes. */
+	isValidForRead?: boolean;
+	/**
+	 * True iff the attribute is exposed via the OData / Web API. Hard wall —
+	 * if false, the attribute can't be selected, filtered, ordered, or
+	 * written to. We filter server-side AND drop the column at
+	 * mapAttribute time, so consumers should never see `false` here. The
+	 * field is carried for diagnostics + future "show all attributes"
+	 * affordances.
+	 */
+	isValidOData?: boolean;
+	description?: string;
 
-  /**
-   * Pre-computed OData attribute reference — the string DRS emits when
-   * the column appears in `$select`, on the LHS of a `$filter` rule, or
-   * inside an inner `$expand($select=...)`.
-   *
-   * For Lookup / Customer / Owner this is `_<logicalName>_value` (the
-   * primitive GUID property in the OData schema). For every other
-   * AttributeType it equals `logicalName`. Computed once in
-   * `metadataProvider.mapAttribute` so encoders don't have to re-derive
-   * it at every emit site. Optional during the type-only transition so
-   * mock fixtures and tests don't break — encoders fall back to
-   * `logicalName` when it's absent.
-   */
-  oDataName?: string;
+	/**
+	 * Pre-computed OData attribute reference — the string DRS emits when
+	 * the column appears in `$select`, on the LHS of a `$filter` rule, or
+	 * inside an inner `$expand($select=...)`.
+	 *
+	 * For Lookup / Customer / Owner this is `_<logicalName>_value` (the
+	 * primitive GUID property in the OData schema). For every other
+	 * AttributeType it equals `logicalName`. Computed once in
+	 * `metadataProvider.mapAttribute` so encoders don't have to re-derive
+	 * it at every emit site. Optional during the type-only transition so
+	 * mock fixtures and tests don't break — encoders fall back to
+	 * `logicalName` when it's absent.
+	 */
+	oDataName?: string;
 
-  // ── Performance-relevant flags (drive antipattern advisories) ──
-  // Mapped from AttributeMetadata.IsLogical (Web API):
-  //   IsLogical = true → column lives in a different physical table; included
-  //   in $select forces a join. Per query-antipatterns LargeAmountOfLogicalAttributes.
-  isLogical?: boolean;
+	// ── Performance-relevant flags (drive antipattern advisories) ──
+	// Mapped from AttributeMetadata.IsLogical (Web API):
+	//   IsLogical = true → column lives in a different physical table; included
+	//   in $select forces a join. Per query-antipatterns LargeAmountOfLogicalAttributes.
+	isLogical?: boolean;
 
-  // Mapped from AttributeMetadata.SourceType (Web API):
-  //   non-null → specialized (calculated/rollup/formula/prompt). When set on
-  //   a column used in $filter, Dataverse throws FilteringOnCalculatedColumns
-  //   anti-pattern errors and may throttle the query.
-  sourceType?: SourceType;
+	// Mapped from AttributeMetadata.SourceType (Web API):
+	//   non-null → specialized (calculated/rollup/formula/prompt). When set on
+	//   a column used in $filter, Dataverse throws FilteringOnCalculatedColumns
+	//   anti-pattern errors and may throttle the query.
+	sourceType?: SourceType;
 }
 
 export interface StringColumnMeta extends BaseColumnMeta {
-  attributeType: 'String';
-  format: StringFormat;
-  maxLength: number;
+	attributeType: "String";
+	format: StringFormat;
+	maxLength: number;
 }
 export interface MemoColumnMeta extends BaseColumnMeta {
-  attributeType: 'Memo';
-  format: MemoFormat;
-  maxLength: number;
+	attributeType: "Memo";
+	format: MemoFormat;
+	maxLength: number;
 }
 export interface IntegerColumnMeta extends BaseColumnMeta {
-  attributeType: 'Integer';
-  format: IntegerFormat;
-  minValue?: number;
-  maxValue?: number;
+	attributeType: "Integer";
+	format: IntegerFormat;
+	minValue?: number;
+	maxValue?: number;
 }
 export interface BigIntColumnMeta extends BaseColumnMeta {
-  attributeType: 'BigInt';
-  minValue?: number;
-  maxValue?: number;
+	attributeType: "BigInt";
+	minValue?: number;
+	maxValue?: number;
 }
 export interface DecimalColumnMeta extends BaseColumnMeta {
-  attributeType: 'Decimal';
-  precision: number;
-  minValue?: number;
-  maxValue?: number;
+	attributeType: "Decimal";
+	precision: number;
+	minValue?: number;
+	maxValue?: number;
 }
 export interface DoubleColumnMeta extends BaseColumnMeta {
-  attributeType: 'Double';
-  precision: number;
-  minValue?: number;
-  maxValue?: number;
+	attributeType: "Double";
+	precision: number;
+	minValue?: number;
+	maxValue?: number;
 }
 export interface MoneyColumnMeta extends BaseColumnMeta {
-  attributeType: 'Money';
-  /** 0=Specific 1=Currency Decimal Precision 2=Pricing Decimal Precision */
-  precisionSource: 0 | 1 | 2;
-  precision: number;
-  minValue?: number;
-  maxValue?: number;
+	attributeType: "Money";
+	/** 0=Specific 1=Currency Decimal Precision 2=Pricing Decimal Precision */
+	precisionSource: 0 | 1 | 2;
+	precision: number;
+	minValue?: number;
+	maxValue?: number;
 }
 export interface BooleanColumnMeta extends BaseColumnMeta {
-  attributeType: 'Boolean';
-  trueOption:  { value: 1; label: string };
-  falseOption: { value: 0; label: string };
-  defaultValue?: boolean;
+	attributeType: "Boolean";
+	trueOption: { value: 1; label: string };
+	falseOption: { value: 0; label: string };
+	defaultValue?: boolean;
 }
 export interface DateTimeColumnMeta extends BaseColumnMeta {
-  attributeType: 'DateTime';
-  format: DateTimeFormat;
-  dateTimeBehavior: DateTimeBehavior;
+	attributeType: "DateTime";
+	format: DateTimeFormat;
+	dateTimeBehavior: DateTimeBehavior;
 }
 export interface PicklistColumnMeta extends BaseColumnMeta {
-  attributeType: 'Picklist';
-  options: { value: number; label: string }[];
-  isGlobal?: boolean;
-  defaultFormValue?: number;
+	attributeType: "Picklist";
+	options: { value: number; label: string }[];
+	isGlobal?: boolean;
+	defaultFormValue?: number;
 }
 export interface MultiSelectPicklistColumnMeta extends BaseColumnMeta {
-  attributeType: 'MultiSelectPicklist';
-  options: { value: number; label: string }[];
+	attributeType: "MultiSelectPicklist";
+	options: { value: number; label: string }[];
 }
 export interface StateColumnMeta extends BaseColumnMeta {
-  attributeType: 'State';
-  options: { value: number; label: string }[];
+	attributeType: "State";
+	options: { value: number; label: string }[];
 }
 export interface StatusColumnMeta extends BaseColumnMeta {
-  attributeType: 'Status';
-  /** statuscode entries with a back-reference to the state value */
-  options: { value: number; label: string; state: number }[];
+	attributeType: "Status";
+	/** statuscode entries with a back-reference to the state value */
+	options: { value: number; label: string; state: number }[];
 }
 export interface LookupColumnMeta extends BaseColumnMeta {
-  attributeType: 'Lookup';
-  targets: string[]; // exactly 1 entity in a Lookup
+	attributeType: "Lookup";
+	targets: string[]; // exactly 1 entity in a Lookup
 }
 export interface CustomerColumnMeta extends BaseColumnMeta {
-  attributeType: 'Customer';
-  targets: string[]; // typically ['account','contact']
+	attributeType: "Customer";
+	targets: string[]; // typically ['account','contact']
 }
 export interface OwnerColumnMeta extends BaseColumnMeta {
-  attributeType: 'Owner';
-  targets: string[]; // typically ['systemuser','team']
+	attributeType: "Owner";
+	targets: string[]; // typically ['systemuser','team']
 }
 export interface UniqueIdColumnMeta extends BaseColumnMeta {
-  attributeType: 'Uniqueidentifier';
-  isPrimaryKey?: boolean;
+	attributeType: "Uniqueidentifier";
+	isPrimaryKey?: boolean;
 }
 export interface EntityNameColumnMeta extends BaseColumnMeta {
-  attributeType: 'EntityName';
-  options: { value: number; label: string }[];
+	attributeType: "EntityName";
+	options: { value: number; label: string }[];
 }
 export interface FileColumnMeta extends BaseColumnMeta {
-  attributeType: 'File';
-  /** Max file size in KB. Defaults to 32768 (32 MB) per file column doc. Configurable up to 10 GB. */
-  maxSizeInKB?: number;
-  /** Special target table — when set, identifies the underlying body column on attachment/annotation. */
-  binaryTarget?: 'file' | 'annotation' | 'attachment';
+	attributeType: "File";
+	/** Max file size in KB. Defaults to 32768 (32 MB) per file column doc. Configurable up to 10 GB. */
+	maxSizeInKB?: number;
+	/** Special target table — when set, identifies the underlying body column on attachment/annotation. */
+	binaryTarget?: "file" | "annotation" | "attachment";
 }
 export interface ImageColumnMeta extends BaseColumnMeta {
-  attributeType: 'Image';
-  /**
-   * Max file size in KB — image columns max out at 30 MB regardless. Per
-   * image-column-data docs.
-   */
-  maxSizeInKB?: number;
-  /** True for the table's primary image (entityimage). Settable on Create; thumbnail-only. */
-  isPrimaryImage?: boolean;
-  /**
-   * Per [ImageAttributeMetadata.CanStoreFullImage]. When false, only the
-   * 144×144 thumbnail is stored. When true, the full-size original is
-   * downloadable via `?size=full`.
-   */
-  canStoreFullImage?: boolean;
+	attributeType: "Image";
+	/**
+	 * Max file size in KB — image columns max out at 30 MB regardless. Per
+	 * image-column-data docs.
+	 */
+	maxSizeInKB?: number;
+	/** True for the table's primary image (entityimage). Settable on Create; thumbnail-only. */
+	isPrimaryImage?: boolean;
+	/**
+	 * Per [ImageAttributeMetadata.CanStoreFullImage]. When false, only the
+	 * 144×144 thumbnail is stored. When true, the full-size original is
+	 * downloadable via `?size=full`.
+	 */
+	canStoreFullImage?: boolean;
 }
 
 export type ColumnMeta =
-  | StringColumnMeta | MemoColumnMeta
-  | IntegerColumnMeta | BigIntColumnMeta
-  | DecimalColumnMeta | DoubleColumnMeta | MoneyColumnMeta
-  | BooleanColumnMeta | DateTimeColumnMeta
-  | PicklistColumnMeta | MultiSelectPicklistColumnMeta | StateColumnMeta | StatusColumnMeta | EntityNameColumnMeta
-  | LookupColumnMeta | CustomerColumnMeta | OwnerColumnMeta
-  | UniqueIdColumnMeta
-  | FileColumnMeta | ImageColumnMeta;
+	| StringColumnMeta
+	| MemoColumnMeta
+	| IntegerColumnMeta
+	| BigIntColumnMeta
+	| DecimalColumnMeta
+	| DoubleColumnMeta
+	| MoneyColumnMeta
+	| BooleanColumnMeta
+	| DateTimeColumnMeta
+	| PicklistColumnMeta
+	| MultiSelectPicklistColumnMeta
+	| StateColumnMeta
+	| StatusColumnMeta
+	| EntityNameColumnMeta
+	| LookupColumnMeta
+	| CustomerColumnMeta
+	| OwnerColumnMeta
+	| UniqueIdColumnMeta
+	| FileColumnMeta
+	| ImageColumnMeta;
 
 // ============================================================
 // Helpers — type predicates and "options" extractor
 // ============================================================
-export const isLookupLike = (c: ColumnMeta): c is LookupColumnMeta | CustomerColumnMeta | OwnerColumnMeta =>
-  c.attributeType === 'Lookup' || c.attributeType === 'Customer' || c.attributeType === 'Owner';
+export const isLookupLike = (
+	c: ColumnMeta,
+): c is LookupColumnMeta | CustomerColumnMeta | OwnerColumnMeta =>
+	c.attributeType === "Lookup" || c.attributeType === "Customer" || c.attributeType === "Owner";
 
-export const isNumericLike = (c: ColumnMeta): c is IntegerColumnMeta | BigIntColumnMeta | DecimalColumnMeta | DoubleColumnMeta | MoneyColumnMeta =>
-  c.attributeType === 'Integer' || c.attributeType === 'BigInt' ||
-  c.attributeType === 'Decimal' || c.attributeType === 'Double' || c.attributeType === 'Money';
+export const isNumericLike = (
+	c: ColumnMeta,
+): c is
+	| IntegerColumnMeta
+	| BigIntColumnMeta
+	| DecimalColumnMeta
+	| DoubleColumnMeta
+	| MoneyColumnMeta =>
+	c.attributeType === "Integer" ||
+	c.attributeType === "BigInt" ||
+	c.attributeType === "Decimal" ||
+	c.attributeType === "Double" ||
+	c.attributeType === "Money";
 
 export const isDateLike = (c: ColumnMeta): c is DateTimeColumnMeta =>
-  c.attributeType === 'DateTime';
+	c.attributeType === "DateTime";
 
 export const isTextLike = (c: ColumnMeta): c is StringColumnMeta | MemoColumnMeta =>
-  c.attributeType === 'String' || c.attributeType === 'Memo';
+	c.attributeType === "String" || c.attributeType === "Memo";
 
-export const isOptionSetLike = (c: ColumnMeta): c is PicklistColumnMeta | MultiSelectPicklistColumnMeta | StateColumnMeta | StatusColumnMeta | EntityNameColumnMeta | BooleanColumnMeta =>
-  c.attributeType === 'Picklist' || c.attributeType === 'MultiSelectPicklist' ||
-  c.attributeType === 'State' || c.attributeType === 'Status' ||
-  c.attributeType === 'EntityName' || c.attributeType === 'Boolean';
+export const isOptionSetLike = (
+	c: ColumnMeta,
+): c is
+	| PicklistColumnMeta
+	| MultiSelectPicklistColumnMeta
+	| StateColumnMeta
+	| StatusColumnMeta
+	| EntityNameColumnMeta
+	| BooleanColumnMeta =>
+	c.attributeType === "Picklist" ||
+	c.attributeType === "MultiSelectPicklist" ||
+	c.attributeType === "State" ||
+	c.attributeType === "Status" ||
+	c.attributeType === "EntityName" ||
+	c.attributeType === "Boolean";
 
 /** Returns the option list for any choice/state/status/boolean column, else undefined. */
 export function columnOptions(c: ColumnMeta): { value: number; label: string }[] | undefined {
-  if (c.attributeType === 'Picklist' || c.attributeType === 'MultiSelectPicklist' ||
-      c.attributeType === 'State' || c.attributeType === 'Status' || c.attributeType === 'EntityName') {
-    return c.options;
-  }
-  if (c.attributeType === 'Boolean') {
-    return [c.falseOption, c.trueOption];
-  }
-  return undefined;
+	if (
+		c.attributeType === "Picklist" ||
+		c.attributeType === "MultiSelectPicklist" ||
+		c.attributeType === "State" ||
+		c.attributeType === "Status" ||
+		c.attributeType === "EntityName"
+	) {
+		return c.options;
+	}
+	if (c.attributeType === "Boolean") {
+		return [c.falseOption, c.trueOption];
+	}
+	return undefined;
 }
 
 export const isHiddenInFilter = (c: ColumnMeta): boolean =>
-  c.attributeType === 'File' || c.attributeType === 'Image';
+	c.attributeType === "File" || c.attributeType === "Image";
 
 // ── Antipattern predicates (sourced from query-antipatterns docs) ───────────
 // Reference: https://learn.microsoft.com/en-us/power-apps/developer/data-platform/query-antipatterns
@@ -304,9 +368,9 @@ export const isHiddenInFilter = (c: ColumnMeta): boolean =>
  *   - String columns are large when MaxLength > 850.
  */
 export const isLargeText = (c: ColumnMeta): boolean => {
-  if (c.attributeType === 'Memo') return true;
-  if (c.attributeType === 'String' && c.maxLength > 850) return true;
-  return false;
+	if (c.attributeType === "Memo") return true;
+	if (c.attributeType === "String" && c.maxLength > 850) return true;
+	return false;
 };
 
 /**
@@ -315,19 +379,23 @@ export const isLargeText = (c: ColumnMeta): boolean => {
  *   computed at retrieval time and trigger FilteringOnCalculatedColumns.
  */
 export const isComputedColumn = (c: ColumnMeta): boolean =>
-  c.sourceType != null && c.sourceType > 0;
+	c.sourceType != null && c.sourceType > 0;
 
 /**
  * Human-readable label for SourceType. Used in advisory copy.
  */
 export const sourceTypeLabel = (s: SourceType | undefined): string | undefined => {
-  if (s == null || s === 0) return undefined;
-  switch (s) {
-    case 1: return 'calculated';
-    case 2: return 'rollup';
-    case 3: return 'formula';
-    case 4: return 'prompt';
-  }
+	if (s == null || s === 0) return undefined;
+	switch (s) {
+		case 1:
+			return "calculated";
+		case 2:
+			return "rollup";
+		case 3:
+			return "formula";
+		case 4:
+			return "prompt";
+	}
 };
 
 /**
@@ -338,47 +406,67 @@ export const sourceTypeLabel = (s: SourceType | undefined): string | undefined =
 export const isLogicalColumn = (c: ColumnMeta): boolean => c.isLogical === true;
 
 /** Underlying Edm type — used for OData literal rendering. */
-export function edmTypeOf(c: ColumnMeta): 'string' | 'number' | 'integer' | 'boolean' | 'date' | 'datetime' | 'guid' {
-  switch (c.attributeType) {
-    case 'String': case 'Memo':                                     return 'string';
-    case 'Integer': case 'BigInt':                                   return 'integer';
-    case 'Decimal': case 'Double': case 'Money':                     return 'number';
-    case 'Boolean':                                                  return 'boolean';
-    case 'DateTime':                                                 return c.format === 'DateOnly' ? 'date' : 'datetime';
-    case 'Lookup': case 'Customer': case 'Owner': case 'Uniqueidentifier': return 'guid';
-    case 'Picklist': case 'MultiSelectPicklist':
-    case 'State': case 'Status': case 'EntityName':                  return 'integer';
-    default:                                                          return 'string';
-  }
+export function edmTypeOf(
+	c: ColumnMeta,
+): "string" | "number" | "integer" | "boolean" | "date" | "datetime" | "guid" {
+	switch (c.attributeType) {
+		case "String":
+		case "Memo":
+			return "string";
+		case "Integer":
+		case "BigInt":
+			return "integer";
+		case "Decimal":
+		case "Double":
+		case "Money":
+			return "number";
+		case "Boolean":
+			return "boolean";
+		case "DateTime":
+			return c.format === "DateOnly" ? "date" : "datetime";
+		case "Lookup":
+		case "Customer":
+		case "Owner":
+		case "Uniqueidentifier":
+			return "guid";
+		case "Picklist":
+		case "MultiSelectPicklist":
+		case "State":
+		case "Status":
+		case "EntityName":
+			return "integer";
+		default:
+			return "string";
+	}
 }
 
 // ============================================================
 // Navigation properties (relationships) — used by $expand + lambda
 // ============================================================
 export interface NavProperty {
-  name: string;
-  relationshipName: string;
-  cardinality: 'OneToMany' | 'ManyToOne' | 'ManyToMany';
-  targetEntity: string;
-  /**
-   * For ManyToOne navs: the source-side attribute logical name (e.g.
-   * `regardingobjectid`, `customerid`, `primarycontactid`). The FK column.
-   *
-   * Critical for resolving the correct `@odata.bind` property name on
-   * polymorphic lookups. Customer/Owner-like and multi-target Lookups have
-   * MULTIPLE NavProperty entries with the same `referencingAttribute` but
-   * different `targetEntity` and different `name` (the target-disambiguated
-   * nav-property name, e.g. `customerid_account` vs `customerid_contact`,
-   * or `regardingobjectid_account_task` vs `regardingobjectid_contact_task`).
-   *
-   * When the encoder builds a write body and a user picks a target for a
-   * polymorphic lookup, we match by `(referencingAttribute === col.logicalName
-   * && targetEntity === picked.targetEntity)` and emit `<navName>@odata.bind`.
-   *
-   * Always undefined for OneToMany / ManyToMany navs (which don't have a
-   * single source attribute).
-   */
-  referencingAttribute?: string;
+	name: string;
+	relationshipName: string;
+	cardinality: "OneToMany" | "ManyToOne" | "ManyToMany";
+	targetEntity: string;
+	/**
+	 * For ManyToOne navs: the source-side attribute logical name (e.g.
+	 * `regardingobjectid`, `customerid`, `primarycontactid`). The FK column.
+	 *
+	 * Critical for resolving the correct `@odata.bind` property name on
+	 * polymorphic lookups. Customer/Owner-like and multi-target Lookups have
+	 * MULTIPLE NavProperty entries with the same `referencingAttribute` but
+	 * different `targetEntity` and different `name` (the target-disambiguated
+	 * nav-property name, e.g. `customerid_account` vs `customerid_contact`,
+	 * or `regardingobjectid_account_task` vs `regardingobjectid_contact_task`).
+	 *
+	 * When the encoder builds a write body and a user picks a target for a
+	 * polymorphic lookup, we match by `(referencingAttribute === col.logicalName
+	 * && targetEntity === picked.targetEntity)` and emit `<navName>@odata.bind`.
+	 *
+	 * Always undefined for OneToMany / ManyToMany navs (which don't have a
+	 * single source attribute).
+	 */
+	referencingAttribute?: string;
 }
 
 /**
@@ -389,26 +477,26 @@ export interface NavProperty {
  * See https://learn.microsoft.com/en-us/power-apps/maker/data-platform/define-alternate-keys-reference-records
  */
 export interface AlternateKeyDef {
-  /** Internal name of the key definition (e.g. `akey_accountnumber`). */
-  name: string;
-  /** UI label — e.g. "By Account Number". */
-  displayName: string;
-  /** Column logical names that make up the key (order matters in the URL). */
-  columns: string[];
+	/** Internal name of the key definition (e.g. `akey_accountnumber`). */
+	name: string;
+	/** UI label — e.g. "By Account Number". */
+	displayName: string;
+	/** Column logical names that make up the key (order matters in the URL). */
+	columns: string[];
 }
 
 export interface TableMeta {
-  logicalName: string;
-  entitySetName: string;
-  displayName: string;
-  primaryKey: string;
-  primaryName: string;
-  columns: ColumnMeta[];
-  navigationProperties: NavProperty[];
-  /** Alternate keys defined on the table (optional — used by Upsert). */
-  alternateKeys?: AlternateKeyDef[];
-  /** True if this table is one of the Merge-supported types (account / contact / incident). */
-  supportsMerge?: boolean;
+	logicalName: string;
+	entitySetName: string;
+	displayName: string;
+	primaryKey: string;
+	primaryName: string;
+	columns: ColumnMeta[];
+	navigationProperties: NavProperty[];
+	/** Alternate keys defined on the table (optional — used by Upsert). */
+	alternateKeys?: AlternateKeyDef[];
+	/** True if this table is one of the Merge-supported types (account / contact / incident). */
+	supportsMerge?: boolean;
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -429,22 +517,24 @@ const __liveTables = new Map<string, TableMeta>();
 const __liveListeners = new Set<() => void>();
 
 export function __registerLiveTable(t: TableMeta): void {
-  __liveTables.set(t.logicalName, t);
-  for (const l of __liveListeners) l();
+	__liveTables.set(t.logicalName, t);
+	for (const l of __liveListeners) l();
 }
 export function __registerLiveTables(list: TableMeta[]): void {
-  for (const t of list) __liveTables.set(t.logicalName, t);
-  for (const l of __liveListeners) l();
+	for (const t of list) __liveTables.set(t.logicalName, t);
+	for (const l of __liveListeners) l();
 }
 export function __subscribeLiveTables(cb: () => void): () => void {
-  __liveListeners.add(cb);
-  return () => __liveListeners.delete(cb);
+	__liveListeners.add(cb);
+	return () => __liveListeners.delete(cb);
 }
 export function __clearLiveTables(): void {
-  __liveTables.clear();
-  for (const l of __liveListeners) l();
+	__liveTables.clear();
+	for (const l of __liveListeners) l();
 }
-export function __hasLiveTables(): boolean { return __liveTables.size > 0; }
+export function __hasLiveTables(): boolean {
+	return __liveTables.size > 0;
+}
 
 /**
  * Live-only entity list. Empty until the metadata provider has fetched and
@@ -454,7 +544,7 @@ export function __hasLiveTables(): boolean { return __liveTables.size > 0; }
  * actually wants).
  */
 export function getLiveTables(): TableMeta[] {
-  return Array.from(__liveTables.values());
+	return Array.from(__liveTables.values());
 }
 
 /**
@@ -463,15 +553,19 @@ export function getLiveTables(): TableMeta[] {
  * via a Proxy so it stays fresh as new tables are registered.
  */
 export const TABLES: TableMeta[] = new Proxy([] as TableMeta[], {
-  get(_t, key: string | symbol) {
-    const arr = Array.from(__liveTables.values());
-    return arr[key as keyof typeof arr];
-  },
-  has(_t, key) { return key in Array.from(__liveTables.values()); },
-  ownKeys() { return Reflect.ownKeys(Array.from(__liveTables.values())); },
-  getOwnPropertyDescriptor(_t, key) {
-    return Object.getOwnPropertyDescriptor(Array.from(__liveTables.values()), key);
-  },
+	get(_t, key: string | symbol) {
+		const arr = Array.from(__liveTables.values());
+		return arr[key as keyof typeof arr];
+	},
+	has(_t, key) {
+		return key in Array.from(__liveTables.values());
+	},
+	ownKeys() {
+		return Reflect.ownKeys(Array.from(__liveTables.values()));
+	},
+	getOwnPropertyDescriptor(_t, key) {
+		return Object.getOwnPropertyDescriptor(Array.from(__liveTables.values()), key);
+	},
 });
 
 /**
@@ -481,10 +575,10 @@ export const TABLES: TableMeta[] = new Proxy([] as TableMeta[], {
  * editors re-render when a fetch resolves.
  */
 export const findTable = (logicalName: string): TableMeta | undefined =>
-  __liveTables.get(logicalName);
+	__liveTables.get(logicalName);
 
 export const findColumn = (table: TableMeta, logicalName: string): ColumnMeta | undefined =>
-  table.columns.find(c => c.logicalName === logicalName);
+	table.columns.find((c) => c.logicalName === logicalName);
 
 // ══════════════════════════════════════════════════════════════════════
 // Canonical nav-path resolver — SINGLE SOURCE OF TRUTH.
@@ -512,17 +606,17 @@ export const findColumn = (table: TableMeta, logicalName: string): ColumnMeta | 
 // render. This is the same self-healing contract the lambda encoder relies on.
 
 export interface ResolvedNavPath {
-  /** The resolved leaf column, on the deepest entity. Undefined when the
-   *  path can't be fully resolved (bad segment, or a hop not yet loaded). */
-  leaf?: ColumnMeta;
-  /** The entity the leaf lives on (the deepest entity walked). For a bare
-   *  column this is the root table. */
-  ownerTable?: TableMeta;
-  /** Entities visited, starting with the root: `[root, …related]`. */
-  chain: TableMeta[];
-  /** Logical name of the first nav target NOT yet in the live registry, if
-   *  any. Drives lazy-loading; undefined once the whole chain is resolvable. */
-  pendingTarget?: string;
+	/** The resolved leaf column, on the deepest entity. Undefined when the
+	 *  path can't be fully resolved (bad segment, or a hop not yet loaded). */
+	leaf?: ColumnMeta;
+	/** The entity the leaf lives on (the deepest entity walked). For a bare
+	 *  column this is the root table. */
+	ownerTable?: TableMeta;
+	/** Entities visited, starting with the root: `[root, …related]`. */
+	chain: TableMeta[];
+	/** Logical name of the first nav target NOT yet in the live registry, if
+	 *  any. Drives lazy-loading; undefined once the whole chain is resolvable. */
+	pendingTarget?: string;
 }
 
 /**
@@ -537,38 +631,38 @@ export interface ResolvedNavPath {
  *   `primarycontactid/name`).
  */
 export function resolveNavPath(
-  rootTable: TableMeta | undefined,
-  path: string,
-  opts?: { alias?: string },
+	rootTable: TableMeta | undefined,
+	path: string,
+	opts?: { alias?: string },
 ): ResolvedNavPath {
-  if (!rootTable) return { chain: [] };
-  let p = path;
-  const alias = opts?.alias;
-  if (alias && p.startsWith(alias + '/')) p = p.slice(alias.length + 1);
-  const segs = p.split('/').filter(Boolean);
-  const chain: TableMeta[] = [rootTable];
-  if (segs.length === 0) return { ownerTable: rootTable, chain };
+	if (!rootTable) return { chain: [] };
+	let p = path;
+	const alias = opts?.alias;
+	if (alias && p.startsWith(alias + "/")) p = p.slice(alias.length + 1);
+	const segs = p.split("/").filter(Boolean);
+	const chain: TableMeta[] = [rootTable];
+	if (segs.length === 0) return { ownerTable: rootTable, chain };
 
-  let current: TableMeta = rootTable;
-  // Walk every segment except the leaf as an N:1 nav hop.
-  for (let i = 0; i < segs.length - 1; i++) {
-    const nav = current.navigationProperties.find(
-      n => n.name === segs[i] && n.cardinality === 'ManyToOne',
-    );
-    // Unknown nav segment — can't go deeper; report what we have.
-    if (!nav) return { ownerTable: current, chain };
-    const target = findTable(nav.targetEntity);
-    // Target not loaded yet — surface it for lazy-loading + re-resolve later.
-    if (!target) return { ownerTable: current, chain, pendingTarget: nav.targetEntity };
-    chain.push(target);
-    current = target;
-  }
-  const leafSeg = segs[segs.length - 1];
-  return {
-    leaf: current.columns.find(c => c.logicalName === leafSeg || c.oDataName === leafSeg),
-    ownerTable: current,
-    chain,
-  };
+	let current: TableMeta = rootTable;
+	// Walk every segment except the leaf as an N:1 nav hop.
+	for (let i = 0; i < segs.length - 1; i++) {
+		const nav = current.navigationProperties.find(
+			(n) => n.name === segs[i] && n.cardinality === "ManyToOne",
+		);
+		// Unknown nav segment — can't go deeper; report what we have.
+		if (!nav) return { ownerTable: current, chain };
+		const target = findTable(nav.targetEntity);
+		// Target not loaded yet — surface it for lazy-loading + re-resolve later.
+		if (!target) return { ownerTable: current, chain, pendingTarget: nav.targetEntity };
+		chain.push(target);
+		current = target;
+	}
+	const leafSeg = segs[segs.length - 1];
+	return {
+		leaf: current.columns.find((c) => c.logicalName === leafSeg || c.oDataName === leafSeg),
+		ownerTable: current,
+		chain,
+	};
 }
 
 /**
@@ -585,9 +679,7 @@ export function resolveNavPath(
  * (subject on activities, address composites on customer tables, etc.).
  */
 export function isCompanionLogicalReadOnly(c: ColumnMeta): boolean {
-  return c.isLogical === true
-      && c.isValidForCreate === false
-      && c.isValidForUpdate === false;
+	return c.isLogical === true && c.isValidForCreate === false && c.isValidForUpdate === false;
 }
 
 // ══════════════════════════════════════════════════════════════════════
@@ -601,14 +693,13 @@ export function isCompanionLogicalReadOnly(c: ColumnMeta): boolean {
 // a follow-up pass.
 
 export interface SavedQuery {
-  id: string;
-  name: string;
-  type: 'savedQuery' | 'userQuery';
-  entity: string;
-  description: string;
-  filterSummary: string;
-  columns: string[];
+	id: string;
+	name: string;
+	type: "savedQuery" | "userQuery";
+	entity: string;
+	description: string;
+	filterSummary: string;
+	columns: string[];
 }
 
 export const SAVED_QUERIES: SavedQuery[] = [];
-

--- a/src/mock/metadata.ts
+++ b/src/mock/metadata.ts
@@ -564,7 +564,11 @@ export function resolveNavPath(
     current = target;
   }
   const leafSeg = segs[segs.length - 1];
-  return { leaf: current.columns.find(c => c.logicalName === leafSeg), ownerTable: current, chain };
+  return {
+    leaf: current.columns.find(c => c.logicalName === leafSeg || c.oDataName === leafSeg),
+    ownerTable: current,
+    chain,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to PR #35 addressing three issues raised in the post-merge review:

- **Race condition in `refreshAll()`** — drain in-flight `buildTable` promises via `Promise.allSettled` before clearing the cache, so no orphaned fetch can re-register stale metadata after the refresh.
- **Silent bad-hop in OData parse validation** — when `validateFilterColumns` encounters a segment that is not a ManyToOne navigation (or whose target entity times out), it now emits an actionable warning naming the bad segment and owner table instead of silently continuing.
- **`resolveNavPath` leaf misses `oDataName`** — leaf column search now checks both `logicalName` and `oDataName`, so pasted/round-tripped OData with the `_<x>_value` lookup wire form as the path leaf resolves to the correct `ColumnMeta` (correct quoting in the encoder) rather than falling back to `undefined`.

Also includes Prettier formatting normalisation across the three changed source files and bumps the version to **v1.1.2**.

## Test plan

- [x] Parse `contacts?$filter=parentaccountid/_ownerid_value eq 00000000-0000-0000-0000-000000000001` — applies cleanly, GUID unquoted in URL bar
- [x] Parse `accounts?$filter=fakeproperty/fullname eq 'Contoso'` — warning: `` `fakeproperty` is not a ManyToOne navigation on `account` ``
- [x] Parse `accounts?$filter=contact_customer_accounts/jobtitle eq 'Manager'` — warning on bad (OneToMany) hop
- [x] Parse `accounts?$filter=primarycontactid/nonexistentcolumn eq 'x'` — warning: column not found on contact
- [x] Settings → Refresh metadata while a table is loading — no stale metadata after refresh completes
- [x] Regression: `opportunities?$filter=parentaccountid/industrycode eq 1` — integer unquoted ✓